### PR TITLE
feat: add native protobuf support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.vscode
 /.cache
+/.idea
 /target
 compile_commands.json
 compile_commands.events.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,8 @@ arc-slice = { workspace = true, features = ["default-layout-any-buffer"] }
 [dev-dependencies]
 tokio = { workspace = true, features = ["time", "rt-multi-thread", "macros"] }
 async-std = { workspace = true, features = ["attributes"] }
+prost = "0.14"
+protox = "0.9"
 
 [[example]]
 name = "basic"
@@ -128,3 +130,11 @@ required-features = ["derive", "async-std"]
 name = "smol"
 path = "examples/async/smol.rs"
 required-features = ["derive", "smol"]
+
+[[example]]
+name = "protobuf"
+path = "examples/protobuf.rs"
+
+[[example]]
+name = "protobuf-advanced"
+path = "examples/protobuf-advanced.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,9 @@ targets = []
 [features]
 default = ["derive"]
 derive = ["dep:cel-cxx-macros"]
+prost = ["cel-cxx-macros/prost", "dep:prost-build"]
+protobuf-legacy = ["cel-cxx-macros/protobuf-legacy", "dep:protobuf-codegen", "dep:protobuf"]
+protobuf = ["cel-cxx-macros/protobuf"]
 async = ["dep:async-scoped", "dep:futures", "dep:pin-project-lite"]
 tokio = ["async", "dep:tokio", "async-scoped/use-tokio"]
 async-std = ["async", "dep:async-std", "async-scoped/use-async-std"]
@@ -96,10 +99,17 @@ async-scoped = { workspace = true, optional = true }
 pin-project-lite = { workspace = true, optional = true }
 arc-slice = { workspace = true, features = ["default-layout-any-buffer"] }
 
+[build-dependencies]
+prost-build = { version = "0.14", optional = true }
+protobuf-codegen = { version = "3", optional = true }
+protobuf = { version = "3", optional = true }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["time", "rt-multi-thread", "macros"] }
 async-std = { workspace = true, features = ["attributes"] }
 prost = "0.14"
+prost-types = "0.14"
+protobuf = "3"
 protox = "0.9"
 
 [[example]]
@@ -138,3 +148,13 @@ path = "examples/protobuf.rs"
 [[example]]
 name = "protobuf-advanced"
 path = "examples/protobuf-advanced.rs"
+
+[[example]]
+name = "protobuf-prost-derive"
+path = "examples/protobuf-prost-derive.rs"
+required-features = ["prost"]
+
+[[example]]
+name = "protobuf-legacy-derive"
+path = "examples/protobuf-legacy-derive.rs"
+required-features = ["protobuf-legacy"]

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ cargo ndk --target i686-linux-android build
 | **Conditionals** | ✅ | Ternary operator and logical short-circuiting |
 | **Comprehensions** | ✅ | List and map comprehensions with filtering |
 | **Custom Types** | ✅ | Opaque types via `#[derive(Opaque)]` |
-| **Protobuf Message Type** | 🚧 Planned | Direct support for protobuf messages and enums as native CEL types with field access (e.g., `p.x`). See [issue #1](https://github.com/xjasonli/cel-cxx/issues/1) |
+| **Protobuf Message Type** | ✅ | Native protobuf messages and enums as first-class CEL types with field access, message construction, and round-trip serialization |
 | **Macros** | ✅ | CEL macro expansion support |
 | **Function Overloads** | ✅ | Multiple function signatures with automatic resolution |
 | **Type Checking** | ✅ | Compile-time type validation |
@@ -400,6 +400,114 @@ cargo ndk --target i686-linux-android build
 | **Async Support** | ✅ | Async function calls and evaluation with Tokio integration |
 | **Custom Extensions** | ✅ | Build and register custom CEL extensions |
 | **Performance Optimization** | ✅ | Optimized evaluation with caching and short-circuiting |
+
+## Protobuf Integration
+
+cel-cxx supports native Protocol Buffer messages as first-class CEL types. You can bind serialized protobuf messages as variables, access their fields in CEL expressions, construct new messages, and extract results back to Rust.
+
+### Compiling Proto Descriptors
+
+CEL needs a `FileDescriptorSet` (a binary descriptor file) to understand your `.proto` types.
+The recommended approach is [`protox`](https://crates.io/crates/protox), a pure-Rust protobuf
+compiler that requires no external binary:
+
+```rust,no_run
+use prost::Message;
+
+let fds = protox::compile(["proto/my_service.proto"], ["proto/"]).unwrap();
+let descriptor_bytes = fds.encode_to_vec();
+```
+
+Alternatively, you can use `protoc` directly:
+
+```bash
+protoc --descriptor_set_out=descriptors.bin \
+       --include_imports \
+       --proto_path=proto \
+       proto/my_service.proto
+```
+
+### Setting Up the Environment
+
+```rust,no_run
+use cel_cxx::*;
+
+# let descriptor_bytes: Vec<u8> = vec![];
+let env = Env::builder()
+    .with_file_descriptor_set(&descriptor_bytes)
+    .declare_protobuf_variable("msg", "my.package.MyMessage")?
+    .build()?;
+# Ok::<(), cel_cxx::Error>(())
+```
+
+### Binding Protobuf Input
+
+Serialize your message to bytes (e.g., via `prost`) and bind it:
+
+```rust,no_run
+# use cel_cxx::*;
+# let serialized_bytes: Vec<u8> = vec![];
+let activation = Activation::new()
+    .bind_protobuf_variable("msg", "my.package.MyMessage", &serialized_bytes)?;
+# Ok::<(), cel_cxx::Error>(())
+```
+
+### Accessing Fields in CEL
+
+CEL expressions can access all protobuf field types:
+
+```cel
+msg.name                              // scalar fields
+msg.address.city                      // nested message fields
+msg.tags[0]                           // repeated fields
+msg.labels["env"]                     // map fields
+msg.status == my.package.Status.ACTIVE // enum constants
+has(msg.optional_field)               // field presence
+```
+
+### Message Construction
+
+Construct new protobuf messages directly in CEL:
+
+```cel
+my.package.MyMessage{name: "Alice", id: 42}
+```
+
+### Extracting Results
+
+```rust,no_run
+# use cel_cxx::*;
+# fn example(result: Value, env: Env) -> Result<(), Error> {
+// Borrow type name and bytes
+let (type_name, bytes) = result.as_protobuf_bytes()?;
+
+// Or extract an owned StructValue
+let sv = StructValue::from_value(&result)?;
+
+// Read individual fields from Rust
+let name = env.get_protobuf_field(&sv, "name")?;
+let has_name = env.has_protobuf_field(&sv, "name")?;
+# Ok(())
+# }
+```
+
+### Well-Known Type Handling
+
+cel-cpp automatically converts well-known types to their CEL equivalents:
+
+| Protobuf Type | CEL Type | Notes |
+|--------------|----------|-------|
+| `google.protobuf.Duration` | `duration` | Full arithmetic and comparison support |
+| `google.protobuf.Timestamp` | `timestamp` | Full arithmetic and comparison support |
+| `google.protobuf.Int64Value`, `StringValue`, `BoolValue`, ... | Primitives | Auto-unboxed to `int`, `string`, `bool`, etc. |
+| `google.protobuf.Struct` | `map` | Dynamic map with dot-notation access |
+| `google.protobuf.Any` | — | `has()` works; full unpacking depends on cel-cpp support |
+
+### Performance Note
+
+Protobuf messages cross the Rust/C++ FFI boundary via serialization: messages are serialized to bytes on the Rust side and deserialized into arena-allocated C++ messages for evaluation, then serialized back when extracting results. This adds overhead proportional to message size.
+
+Zero-copy is not currently implemented for two reasons. First, the architectural change to keep C++ arena-allocated messages alive across the FFI boundary would be significant. Second, true zero-copy would require both cel-cxx and the Rust protobuf library to link against the *exact same* C++ protobuf library instance so that message pointers can be passed directly across the boundary. The official Google Rust protobuf crate ([`protobuf`](https://crates.io/crates/protobuf)) supports a C++ kernel backend that would make this possible in theory, but it currently requires Bazel (not cargo), and there is no shared `protobuf-cpp-sys` crate that both libraries could depend on. cel-cxx also compiles its own copy of C++ protobuf as part of cel-cpp via cmake, so integrating a shared dependency would require reworking the build. Until the ecosystem converges, serialization/deserialization is the only correct approach.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
     - [Optional Value Support](#optional-value-support)
     - [Extension Libraries](#extension-libraries)
     - [Runtime Features](#runtime-features)
+  - [Protobuf Integration](#protobuf-integration)
+    - [Typed API with Derive Macros](#typed-api-with-derive-macros)
   - [License](#license)
   - [Acknowledgements](#acknowledgements)
 
@@ -49,6 +51,10 @@ cel-cxx = "0.2.4"
 
 # Optional features
 cel-cxx = { version = "0.2.4", features = ["tokio"] }
+
+# Protobuf derive macros (choose your backend)
+cel-cxx = { version = "0.2.4", features = ["prost"] }
+cel-cxx = { version = "0.2.4", features = ["protobuf-legacy"] }
 ```
 
 ### Basic Expression Evaluation
@@ -492,6 +498,32 @@ let has_name = env.has_struct_field(&sv, "name")?;
 # Ok(())
 # }
 ```
+
+### Typed API with Derive Macros
+
+If you have compile-time protobuf types (via `prost-build` or `protobuf-codegen`), derive
+macros let you skip the manual `StructValue::from_bytes` plumbing and use the standard
+typed API instead:
+
+```rust,ignore
+// With the `prost` or `protobuf-legacy` feature enabled:
+let env = Env::builder()
+    .with_file_descriptor_set(&descriptors)
+    .declare_variable::<MyMessage>("msg")?  // instead of declare_variable_with_type(...)
+    .build()?;
+
+let activation = Activation::new()
+    .bind_variable("msg", my_message)?;  // instead of bind_variable_dynamic(...)
+
+let result = program.evaluate(&activation)?;
+let recovered = MyMessage::from_value(&result)?;  // instead of StructValue::from_value(...)
+```
+
+The derives are injected during code generation in your `build.rs` -- one line per type
+for prost, or a small `CustomizeCallback` for protobuf-codegen.
+
+See the **[Protobuf Derive Macros Guide](docs/protobuf-derive.md)** for full setup
+instructions, feature flags, and examples.
 
 ### Well-Known Type Handling
 

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ use cel_cxx::*;
 # let descriptor_bytes: Vec<u8> = vec![];
 let env = Env::builder()
     .with_file_descriptor_set(&descriptor_bytes)
-    .declare_protobuf_variable("msg", "my.package.MyMessage")?
+    .declare_variable_with_type("msg", ValueType::Struct(StructType::new("my.package.MyMessage")))?
     .build()?;
 # Ok::<(), cel_cxx::Error>(())
 ```
@@ -448,7 +448,7 @@ Serialize your message to bytes (e.g., via `prost`) and bind it:
 # use cel_cxx::*;
 # let serialized_bytes: Vec<u8> = vec![];
 let activation = Activation::new()
-    .bind_protobuf_variable("msg", "my.package.MyMessage", &serialized_bytes)?;
+    .bind_variable_dynamic("msg", StructValue::from_bytes("my.package.MyMessage", serialized_bytes))?;
 # Ok::<(), cel_cxx::Error>(())
 ```
 
@@ -478,15 +478,17 @@ my.package.MyMessage{name: "Alice", id: 42}
 ```rust,no_run
 # use cel_cxx::*;
 # fn example(result: Value, env: Env) -> Result<(), Error> {
-// Borrow type name and bytes
-let (type_name, bytes) = result.as_protobuf_bytes()?;
+// Borrow via as_struct()
+let sv = result.as_struct().unwrap();
+let type_name = sv.type_name();
+let bytes = sv.to_bytes();
 
 // Or extract an owned StructValue
 let sv = StructValue::from_value(&result)?;
 
 // Read individual fields from Rust
-let name = env.get_protobuf_field(&sv, "name")?;
-let has_name = env.has_protobuf_field(&sv, "name")?;
+let name = env.get_struct_field(&sv, "name")?;
+let has_name = env.has_struct_field(&sv, "name")?;
 # Ok(())
 # }
 ```

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,56 @@
+fn main() {
+    #[cfg(feature = "prost")]
+    {
+        prost_build::Config::new()
+            .enable_type_names()
+            .type_attribute("test.SimpleMessage", "#[derive(::cel_cxx::ProstValue)]")
+            .type_attribute("test.Address", "#[derive(::cel_cxx::ProstValue)]")
+            .type_attribute("test.Person", "#[derive(::cel_cxx::ProstValue)]")
+            .type_attribute("test.Item", "#[derive(::cel_cxx::ProstValue)]")
+            .type_attribute("test.Order", "#[derive(::cel_cxx::ProstValue)]")
+            .compile_protos(&["tests/fixtures/test.proto"], &["tests/fixtures/"])
+            .expect("prost-build failed");
+    }
+
+    #[cfg(feature = "protobuf-legacy")]
+    {
+        use protobuf_codegen::{Codegen, Customize, CustomizeCallback};
+
+        struct DeriveProtobufLegacyValue;
+
+        impl CustomizeCallback for DeriveProtobufLegacyValue {
+            fn message(
+                &self,
+                _message: &protobuf::reflect::MessageDescriptor,
+            ) -> Customize {
+                Customize::default().before("#[derive(::cel_cxx::ProtobufLegacyValue)]")
+            }
+        }
+
+        Codegen::new()
+            .cargo_out_dir("protobuf_legacy_gen")
+            .input("tests/fixtures/test.proto")
+            .include("tests/fixtures/")
+            .customize_callback(DeriveProtobufLegacyValue)
+            .run_from_script();
+
+        // Strip inner attributes (#![...]) and inner doc comments (//!) so the
+        // generated file can be included inside a `mod { }` block in tests.
+        let out_dir = std::env::var("OUT_DIR").unwrap();
+        let gen_path = format!("{out_dir}/protobuf_legacy_gen/test.rs");
+        let content = std::fs::read_to_string(&gen_path).expect("failed to read generated file");
+
+        let mut result = String::new();
+        for line in content.lines() {
+            if line.starts_with("#!") || line.starts_with("//!") {
+                result.push_str("// (stripped) ");
+                result.push_str(line);
+            } else {
+                result.push_str(line);
+            }
+            result.push('\n');
+        }
+
+        std::fs::write(&gen_path, result).expect("failed to write patched file");
+    }
+}

--- a/crates/cel-cxx-ffi/build.rs
+++ b/crates/cel-cxx-ffi/build.rs
@@ -70,6 +70,7 @@ fn build_ffi(artifacts: &Artifacts) -> Result<()> {
         .flag_if_supported("-Wno-return-type")
         .flag_if_supported("-Wno-sign-compare")
         .flag_if_supported("-Wno-missing-requires")
+        .flag_if_supported("-Wno-nullability-completeness")
         .flag_if_supported("/nologo")
         .flag_if_supported("/EHsc")
         .flag_if_supported("/D_CRT_SECURE_NO_DEPRECATE")

--- a/crates/cel-cxx-ffi/include/protobuf.h
+++ b/crates/cel-cxx-ffi/include/protobuf.h
@@ -5,10 +5,10 @@
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/message.h>
 #include <google/protobuf/dynamic_message.h>
-#include <google/protobuf/descriptor_database.h>
 #include <google/protobuf/descriptor.pb.h>
 #include <rust/cxx.h>
 #include <internal/noop_delete.h>
+#include <limits>
 
 namespace rust::cel_cxx {
 
@@ -28,15 +28,20 @@ inline std::shared_ptr<DescriptorPool> generated_pool() {
 }
 
 inline std::shared_ptr<DescriptorPool> NewDescriptorPool(Slice<const uint8_t> file_descriptor_set) {
-    google::protobuf::FileDescriptorSet fds;
-    if (!fds.ParseFromArray(file_descriptor_set.data(), file_descriptor_set.size())) {
+    if (file_descriptor_set.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
         return nullptr;
     }
-    google::protobuf::SimpleDescriptorDatabase db;
-    for (const auto& file : fds.file()) {
-        db.Add(file);
+    google::protobuf::FileDescriptorSet fds;
+    if (!fds.ParseFromArray(file_descriptor_set.data(), static_cast<int>(file_descriptor_set.size()))) {
+        return nullptr;
     }
-    return std::make_shared<DescriptorPool>(&db);
+    auto pool = std::make_shared<DescriptorPool>(DescriptorPool::generated_pool());
+    for (const auto& file : fds.file()) {
+        if (pool->BuildFile(file) == nullptr) {
+            return nullptr;
+        }
+    }
+    return pool;
 }
 
 inline std::shared_ptr<MessageFactory> generated_factory() {

--- a/crates/cel-cxx-ffi/include/runtime.h
+++ b/crates/cel-cxx-ffi/include/runtime.h
@@ -1,6 +1,7 @@
 #ifndef CEL_CXX_FFI_INCLUDE_RUNTIME_H_
 #define CEL_CXX_FFI_INCLUDE_RUNTIME_H_
 
+#include <limits>
 #include <rust/cxx.h>
 #include <runtime/runtime.h>
 #include <runtime/function.h>
@@ -9,6 +10,8 @@
 #include <runtime/internal/runtime_impl.h>
 #include <runtime/internal/runtime_friend_access.h>
 #include <cel-cxx-ffi/include/absl.h>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/descriptor.pb.h>
 
 namespace rust { inline namespace cxxbridge1 {
 using LazyOverload = ::cel::FunctionRegistry::LazyOverload;
@@ -508,6 +511,72 @@ private:
 
 inline std::unique_ptr<Function> Function_new(Box<AnyFfiFunction> ffi_function) {
     return std::make_unique<AnyFfiFunctionWrapper>(std::move(ffi_function));
+}
+
+// Enum registration helpers
+
+inline void register_enums_from_message(
+    TypeRegistry& type_registry,
+    const google::protobuf::Descriptor* message)
+{
+    if (message == nullptr) return;
+    for (int i = 0; i < message->enum_type_count(); i++) {
+        const auto* enum_desc = message->enum_type(i);
+        std::vector<TypeRegistry::Enumerator> enumerators;
+        for (int j = 0; j < enum_desc->value_count(); j++) {
+            const auto* value = enum_desc->value(j);
+            enumerators.push_back({
+                std::string(value->name()),
+                static_cast<int64_t>(value->number())
+            });
+        }
+        type_registry.RegisterEnum(enum_desc->full_name(), std::move(enumerators));
+    }
+    for (int i = 0; i < message->nested_type_count(); i++) {
+        register_enums_from_message(type_registry, message->nested_type(i));
+    }
+}
+
+inline Status TypeRegistry_register_enums_from_file_descriptor_set(
+    TypeRegistry& type_registry,
+    const google::protobuf::DescriptorPool& descriptor_pool,
+    Slice<const uint8_t> file_descriptor_set_bytes)
+{
+    if (file_descriptor_set_bytes.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
+        return absl::InvalidArgumentError("FileDescriptorSet exceeds maximum size");
+    }
+    google::protobuf::FileDescriptorSet fds;
+    if (!fds.ParseFromArray(file_descriptor_set_bytes.data(),
+                            static_cast<int>(file_descriptor_set_bytes.size()))) {
+        return absl::InvalidArgumentError("Failed to parse FileDescriptorSet");
+    }
+
+    for (const auto& file_proto : fds.file()) {
+        const google::protobuf::FileDescriptor* file =
+            descriptor_pool.FindFileByName(file_proto.name());
+        if (file == nullptr) continue;
+
+        // Register top-level enums
+        for (int i = 0; i < file->enum_type_count(); i++) {
+            const auto* enum_desc = file->enum_type(i);
+            std::vector<TypeRegistry::Enumerator> enumerators;
+            for (int j = 0; j < enum_desc->value_count(); j++) {
+                const auto* value = enum_desc->value(j);
+                enumerators.push_back({
+                    std::string(value->name()),
+                    static_cast<int64_t>(value->number())
+                });
+            }
+            type_registry.RegisterEnum(enum_desc->full_name(), std::move(enumerators));
+        }
+
+        // Register enums nested inside messages
+        for (int i = 0; i < file->message_type_count(); i++) {
+            register_enums_from_message(type_registry, file->message_type(i));
+        }
+    }
+
+    return Status();
 }
 
 } // namespace rust::cel_cxx

--- a/crates/cel-cxx-ffi/include/values.h
+++ b/crates/cel-cxx-ffi/include/values.h
@@ -1,9 +1,12 @@
 #ifndef CEL_CXX_FFI_INCLUDE_COMMON_VALUES_H_
 #define CEL_CXX_FFI_INCLUDE_COMMON_VALUES_H_
 
+#include <limits>
 #include <rust/cxx.h>
 #include <common/value.h>
 #include <common/values/value_builder.h>
+#include <common/values/parsed_message_value.h>
+#include <absl/strings/str_cat.h>
 
 namespace rust::cel_cxx {
 
@@ -313,6 +316,90 @@ inline std::unique_ptr<MapValue> MapValueBuilder_build(
 
 
 // MessageValue
+inline Status MessageValue_from_bytes(
+    const Arena& arena,
+    const DescriptorPool& descriptor_pool,
+    const MessageFactory& message_factory,
+    Str type_name,
+    Slice<const uint8_t> bytes,
+    std::unique_ptr<MessageValue>& result
+) {
+    std::string_view name(type_name.data(), type_name.size());
+    auto descriptor = descriptor_pool.FindMessageTypeByName(name);
+    if (descriptor == nullptr) {
+        return absl::NotFoundError(
+            absl::StrCat("Message type not found: ", name));
+    }
+    // GetPrototype is semantically const but not declared as such in protobuf C++.
+    auto prototype = const_cast<MessageFactory&>(message_factory).GetPrototype(descriptor);
+    if (prototype == nullptr) {
+        return absl::InternalError(
+            absl::StrCat("Failed to get prototype for: ", name));
+    }
+    auto* arena_ptr = &const_cast<Arena&>(arena);
+    auto* message = prototype->New(arena_ptr);
+    if (bytes.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
+        return absl::InvalidArgumentError(
+            absl::StrCat("Message bytes too large for: ", name));
+    }
+    if (!message->ParseFromArray(bytes.data(), static_cast<int>(bytes.size()))) {
+        return absl::InvalidArgumentError(
+            absl::StrCat("Failed to parse bytes as: ", name));
+    }
+    result = std::make_unique<MessageValue>(
+        cel::ParsedMessageValue(message, arena_ptr));
+    return Status();
+}
+
+inline Status MessageValue_to_bytes(
+    const MessageValue& message_value,
+    Vec<uint8_t>& result_vec
+) {
+    const auto& parsed = message_value.GetParsed();
+    std::string serialized;
+    if (!(*parsed).SerializeToString(&serialized)) {
+        return absl::InternalError("Failed to serialize MessageValue to bytes");
+    }
+    result_vec.reserve(serialized.size());
+    std::move(serialized.begin(), serialized.end(), std::back_inserter(result_vec));
+    return Status();
+}
+
+inline String MessageValue_get_type_name(const MessageValue& message_value) {
+    auto name = message_value.GetTypeName();
+    return String(std::string(name));
+}
+
+// MessageValue field access
+inline Status MessageValue_get_field_by_name(
+    const MessageValue& message_value,
+    const DescriptorPool& descriptor_pool,
+    const MessageFactory& message_factory,
+    const Arena& arena,
+    Str field_name,
+    std::unique_ptr<Value>& result
+) {
+    auto value = std::make_unique<Value>();
+    std::string_view name(field_name.data(), field_name.size());
+    auto status = message_value.GetFieldByName(
+        name, &descriptor_pool,
+        &const_cast<MessageFactory&>(message_factory),
+        &const_cast<Arena&>(arena),
+        value.get());
+    if (!status.ok()) return status;
+    result.swap(value);
+    return Status();
+}
+
+inline bool MessageValue_has_field_by_name(
+    const MessageValue& message_value,
+    Str field_name
+) {
+    std::string_view name(field_name.data(), field_name.size());
+    auto result = message_value.HasFieldByName(name);
+    if (!result.ok()) return false;
+    return result.value();
+}
 
 // NullValue
 inline std::unique_ptr<NullValue> NullValue_new() {

--- a/crates/cel-cxx-ffi/src/absl.rs
+++ b/crates/cel-cxx-ffi/src/absl.rs
@@ -549,10 +549,18 @@ impl<'a, T: 'a + SpanElement> Span<'a, T> {
 
 impl<'a, T: 'a + SpanElement + cxx::vector::VectorElement> Span<'a, T> {
     pub fn from_vector(vector: &'a cxx::CxxVector<T>) -> Self {
-        Self {
-            ptr: unsafe { vector.get_unchecked(0) as *const T },
-            len: vector.len(),
-            _marker: std::marker::PhantomData,
+        if vector.is_empty() {
+            Self {
+                ptr: std::ptr::NonNull::dangling().as_ptr(),
+                len: 0,
+                _marker: std::marker::PhantomData,
+            }
+        } else {
+            Self {
+                ptr: unsafe { vector.get_unchecked(0) as *const T },
+                len: vector.len(),
+                _marker: std::marker::PhantomData,
+            }
         }
     }
 }
@@ -589,10 +597,8 @@ impl<'a, T: 'a + SpanElement> std::iter::Iterator for SpanIter<'a, T> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (
-            self.span.len() - self.index,
-            Some(self.span.len() - self.index),
-        )
+        let remaining = self.span.len().saturating_sub(self.index);
+        (remaining, Some(remaining))
     }
 }
 
@@ -627,6 +633,10 @@ pub struct MutSpan<'a, T: 'a + MutSpanElement> {
     _marker: std::marker::PhantomData<&'a mut T>,
 }
 
+// Copy + Clone are required by cxx::kind::Trivial for FFI interop.
+// SAFETY: callers must not use a copied MutSpan to produce aliased &mut references.
+// In practice, MutSpan is only iterated once via iter()/into_iter() immediately after
+// creation from from_vector(), so no aliasing occurs.
 impl<'a, T: 'a + MutSpanElement> Copy for MutSpan<'a, T> {}
 impl<'a, T: 'a + MutSpanElement> Clone for MutSpan<'a, T> {
     fn clone(&self) -> Self {
@@ -662,18 +672,29 @@ impl<'a, T: 'a + MutSpanElement> MutSpan<'a, T> {
 
     pub fn iter(&self) -> MutSpanIter<'a, T> {
         MutSpanIter {
-            span: *self,
+            ptr: self.ptr,
+            len: self.len,
             index: 0,
+            _marker: std::marker::PhantomData,
         }
     }
 }
 
 impl<'a, T: 'a + MutSpanElement + cxx::vector::VectorElement> MutSpan<'a, T> {
     pub fn from_vector(mut vector: Pin<&'a mut cxx::CxxVector<T>>) -> Self {
-        Self {
-            ptr: unsafe { vector.as_mut().index_unchecked_mut(0).get_unchecked_mut() as *mut T },
-            len: vector.len(),
-            _marker: std::marker::PhantomData,
+        let len = vector.len();
+        if len == 0 {
+            Self {
+                ptr: std::ptr::NonNull::dangling().as_ptr(),
+                len: 0,
+                _marker: std::marker::PhantomData,
+            }
+        } else {
+            Self {
+                ptr: unsafe { vector.as_mut().index_unchecked_mut(0).get_unchecked_mut() as *mut T },
+                len,
+                _marker: std::marker::PhantomData,
+            }
         }
     }
 }
@@ -693,27 +714,32 @@ impl<'a, T: 'a + MutSpanElement + cxx::ExternType<Kind = cxx::kind::Trivial>> Mu
 }
 
 pub struct MutSpanIter<'a, T: 'a + MutSpanElement> {
-    span: MutSpan<'a, T>,
+    ptr: *mut T,
+    len: usize,
     index: usize,
+    _marker: std::marker::PhantomData<&'a mut T>,
 }
 
 impl<'a, T: 'a + MutSpanElement> std::iter::Iterator for MutSpanIter<'a, T> {
     type Item = Pin<&'a mut T>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(item) = self.span.get(self.index) {
+        if self.index < self.len {
+            let item = unsafe {
+                self.ptr.byte_add(self.index * T::size_of())
+                    .as_mut()
+                    .map(|ptr| Pin::new_unchecked(ptr))
+            };
             self.index += 1;
-            Some(item)
+            item
         } else {
             None
         }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (
-            self.span.len() - self.index,
-            Some(self.span.len() - self.index),
-        )
+        let remaining = self.len.saturating_sub(self.index);
+        (remaining, Some(remaining))
     }
 }
 impl<'a, T: 'a + MutSpanElement> std::iter::FusedIterator for MutSpanIter<'a, T> {}
@@ -722,7 +748,12 @@ impl<'a, T: 'a + MutSpanElement> std::iter::IntoIterator for &MutSpan<'a, T> {
     type Item = Pin<&'a mut T>;
     type IntoIter = MutSpanIter<'a, T>;
     fn into_iter(self) -> Self::IntoIter {
-        MutSpanIter { span: *self, index: 0 }
+        MutSpanIter {
+            ptr: self.ptr,
+            len: self.len,
+            index: 0,
+            _marker: std::marker::PhantomData,
+        }
     }
 }
 

--- a/crates/cel-cxx-ffi/src/common/decl.rs
+++ b/crates/cel-cxx-ffi/src/common/decl.rs
@@ -1,4 +1,4 @@
-use crate::absl::{Duration, Status, Timestamp};
+use crate::absl::Status;
 use crate::common::{Type, Constant};
 
 #[cxx::bridge]
@@ -6,10 +6,7 @@ mod ffi {
     #[namespace = "absl"]
     unsafe extern "C++" {
         include!(<absl/status/status.h>);
-        include!(<absl/time/time.h>);
         type Status = super::Status;
-        type Time = super::Timestamp;
-        type Duration = super::Duration;
     }
 
     #[namespace = "cel"]

--- a/crates/cel-cxx-ffi/src/common/types.rs
+++ b/crates/cel-cxx-ffi/src/common/types.rs
@@ -513,13 +513,14 @@ impl<'a> OptionalType<'a> {
     }
 }
 
-// StructType contains a StructTypeVariant, which largest member is
-// BasicStructType contains a std::string_view.
+// StructType contains a StructTypeVariant = absl::variant<monostate, BasicStructType, MessageType>.
+// sizeof(StructType) = 24 bytes on 64-bit: 16 bytes payload (BasicStructType = string_view)
+// + 8 bytes variant index (with alignment padding).
 //
-// So we use 2 pointers size to store the type.
+// So we use 3 pointers size to store the type.
 #[repr(transparent)]
 #[derive(Copy, Clone)]
-pub struct StructType<'a>(Rep<'a, usize, 2>);
+pub struct StructType<'a>(Rep<'a, usize, 3>);
 
 unsafe impl<'a> cxx::ExternType for StructType<'a> {
     type Id = cxx::type_id!("cel::StructType");
@@ -644,7 +645,7 @@ impl<'a> std::ops::Index<usize> for TypeParameters<'a> {
     type Output = Type<'a>;
 
     fn index(&self, index: usize) -> &Self::Output {
-        unsafe { self.get_unchecked(index) }
+        self.get(index).expect("TypeParameters index out of bounds")
     }
 }
 

--- a/crates/cel-cxx-ffi/src/common/values.rs
+++ b/crates/cel-cxx-ffi/src/common/values.rs
@@ -262,7 +262,31 @@ mod ffi {
         ) -> UniquePtr<MapValue<'a>>;
 
         // MessageValue
-        // todo: implement
+        fn MessageValue_from_bytes<'a>(
+            arena: &'a Arena,
+            descriptor_pool: &'a DescriptorPool,
+            message_factory: &MessageFactory,
+            type_name: &str,
+            bytes: &[u8],
+            result: &mut UniquePtr<MessageValue<'a>>,
+        ) -> Status;
+        fn MessageValue_to_bytes(
+            message_value: &MessageValue,
+            result_vec: &mut Vec<u8>,
+        ) -> Status;
+        fn MessageValue_get_type_name(message_value: &MessageValue) -> String;
+        fn MessageValue_get_field_by_name<'a>(
+            message_value: &MessageValue<'a>,
+            descriptor_pool: &'a DescriptorPool,
+            message_factory: &MessageFactory,
+            arena: &'a Arena,
+            field_name: &str,
+            result: &mut UniquePtr<Value<'a>>,
+        ) -> Status;
+        fn MessageValue_has_field_by_name(
+            message_value: &MessageValue,
+            field_name: &str,
+        ) -> bool;
 
         // NullValue
         fn NullValue_new() -> UniquePtr<NullValue>;
@@ -669,7 +693,71 @@ pub use ffi::MessageValue;
 unsafe impl<'a> Send for MessageValue<'a> {}
 unsafe impl<'a> Sync for MessageValue<'a> {}
 
-impl<'a> MessageValue<'a> {}
+impl<'a> MessageValue<'a> {
+    pub fn from_bytes(
+        arena: &'a Arena,
+        descriptor_pool: &'a DescriptorPool,
+        message_factory: &'a MessageFactory,
+        type_name: &str,
+        bytes: &[u8],
+    ) -> Result<cxx::UniquePtr<Self>, Status> {
+        let mut result = cxx::UniquePtr::null();
+        let status =
+            ffi::MessageValue_from_bytes(arena, descriptor_pool, message_factory, type_name, bytes, &mut result);
+        if status.is_ok() {
+            Ok(result)
+        } else {
+            Err(status)
+        }
+    }
+
+    pub fn to_bytes(&self) -> Result<Vec<u8>, Status> {
+        let mut result = Vec::new();
+        let status = ffi::MessageValue_to_bytes(self, &mut result);
+        if status.is_ok() {
+            Ok(result)
+        } else {
+            Err(status)
+        }
+    }
+
+    pub fn type_name(&self) -> String {
+        ffi::MessageValue_get_type_name(self)
+    }
+
+    pub fn get_field_by_name(
+        &self,
+        descriptor_pool: &'a DescriptorPool,
+        message_factory: &'a MessageFactory,
+        arena: &'a Arena,
+        field_name: &str,
+    ) -> Result<cxx::UniquePtr<Value<'a>>, Status> {
+        let mut result = cxx::UniquePtr::null();
+        let status = ffi::MessageValue_get_field_by_name(
+            self,
+            descriptor_pool,
+            message_factory,
+            arena,
+            field_name,
+            &mut result,
+        );
+        if status.is_ok() {
+            Ok(result)
+        } else {
+            Err(status)
+        }
+    }
+
+    /// Check if a field is set on the message.
+    ///
+    /// Note: the underlying C++ `HasFieldByName` returns `StatusOr<bool>` but
+    /// this bridge swallows the error and returns `false`. An invalid field name
+    /// is indistinguishable from an unset field. This is a limitation of the
+    /// current C++ bridge; fixing it requires changing the C++ signature.
+    pub fn has_field_by_name(&self, field_name: &str) -> bool {
+        ffi::MessageValue_has_field_by_name(self, field_name)
+    }
+}
 
 pub use ffi::NullValue;
 unsafe impl Send for NullValue {}

--- a/crates/cel-cxx-ffi/src/parser.rs
+++ b/crates/cel-cxx-ffi/src/parser.rs
@@ -1,4 +1,4 @@
-use crate::absl::{Status, StringView, MutSpan};
+use crate::absl::{Status, StringView};
 use crate::common::{Expr, ListExprElement, StructExprField, MapExprEntry};
 use std::pin::Pin;
 
@@ -56,11 +56,6 @@ mod ffi {
         include!(<cel-cxx-ffi/include/parser.h>);
 
         type MacroPredicate;
-
-        type MutSpan_Expr<'a> = super::MutSpan<'a, Expr>;
-        type MutSpan_ListExprElement<'a> = super::MutSpan<'a, ListExprElement>;
-        type MutSpan_StructExprField<'a> = super::MutSpan<'a, StructExprField>;
-        type MutSpan_MapExprEntry<'a> = super::MutSpan<'a, MapExprEntry>;
 
         // GlobalMacroExpander
         fn GlobalMacroExpander_new(ffi_expander: Box<AnyFfiGlobalMacroExpander>) -> UniquePtr<GlobalMacroExpander>;

--- a/crates/cel-cxx-ffi/src/protobuf.rs
+++ b/crates/cel-cxx-ffi/src/protobuf.rs
@@ -60,8 +60,17 @@ impl DescriptorPool {
         ffi::generated_pool()
     }
 
-    pub fn new(file_descriptor_set: &[u8]) -> cxx::SharedPtr<Self> {
-        ffi::NewDescriptorPool(file_descriptor_set)
+    /// Build a `DescriptorPool` from a serialized `FileDescriptorSet`.
+    ///
+    /// Returns `Err` if the bytes are malformed or a file descriptor fails to build.
+    /// The C++ side returns a null `shared_ptr` on any of these failures without
+    /// further detail, so the error message is generic.
+    pub fn new(file_descriptor_set: &[u8]) -> Result<cxx::SharedPtr<Self>, &'static str> {
+        let pool = ffi::NewDescriptorPool(file_descriptor_set);
+        if pool.is_null() {
+            return Err("failed to build DescriptorPool from FileDescriptorSet");
+        }
+        Ok(pool)
     }
 }
 
@@ -84,6 +93,12 @@ impl std::fmt::Debug for DescriptorPool {
 
 // MessageFactory
 pub use ffi::MessageFactory;
+// SAFETY: The generated MessageFactory (singleton) is truly thread-safe.
+// DynamicMessageFactory::GetPrototype() mutates internal caches without synchronization,
+// so it is NOT safe for concurrent shared access. However, the Ctx architecture ensures
+// DynamicMessageFactory is never shared: Ctx::clone_with_new_arena() creates a fresh
+// instance per evaluation context, so each thread gets exclusive access. This invariant
+// is critical — do NOT share a DynamicMessageFactory across threads.
 unsafe impl Send for MessageFactory {}
 unsafe impl Sync for MessageFactory {}
 

--- a/crates/cel-cxx-ffi/src/runtime.rs
+++ b/crates/cel-cxx-ffi/src/runtime.rs
@@ -306,6 +306,13 @@ mod ffi {
         // Function
         fn Function_new<'a>(ffi_function: Box<AnyFfiFunction<'a>>) -> UniquePtr<Function<'a>>;
 
+        // TypeRegistry — enum registration
+        fn TypeRegistry_register_enums_from_file_descriptor_set<'d, 'a>(
+            type_registry: Pin<&mut TypeRegistry<'d, 'a>>,
+            descriptor_pool: &DescriptorPool,
+            file_descriptor_set_bytes: &[u8],
+        ) -> Status;
+
         include!(<cel-cxx-ffi/include/optional.h>);
         fn EnableOptionalTypes(runtime_builder: Pin<&mut RuntimeBuilder>) -> Status;
     }
@@ -970,3 +977,22 @@ impl<'f> AnyFfiFunction<'f> {
 pub use ffi::TypeRegistry;
 unsafe impl<'d, 'a> Send for TypeRegistry<'d, 'a> {}
 unsafe impl<'d, 'a> Sync for TypeRegistry<'d, 'a> {}
+
+impl<'d, 'a> TypeRegistry<'d, 'a> {
+    pub fn register_enums_from_file_descriptor_set(
+        self: Pin<&mut Self>,
+        descriptor_pool: &DescriptorPool,
+        file_descriptor_set_bytes: &[u8],
+    ) -> Result<(), Status> {
+        let status = ffi::TypeRegistry_register_enums_from_file_descriptor_set(
+            self,
+            descriptor_pool,
+            file_descriptor_set_bytes,
+        );
+        if status.is_ok() {
+            Ok(())
+        } else {
+            Err(status)
+        }
+    }
+}

--- a/crates/cel-cxx-macros/Cargo.toml
+++ b/crates/cel-cxx-macros/Cargo.toml
@@ -17,6 +17,11 @@ keywords.workspace = true
 name = "cel_cxx_macros"
 proc-macro = true
 
+[features]
+prost = []
+protobuf-legacy = []
+protobuf = []
+
 [dependencies]
 syn = { workspace = true }
 quote = { workspace = true }

--- a/crates/cel-cxx-macros/src/lib.rs
+++ b/crates/cel-cxx-macros/src/lib.rs
@@ -4,6 +4,15 @@ use proc_macro::TokenStream;
 mod opaque;
 mod symbol;
 
+#[cfg(feature = "prost")]
+mod prost_value;
+
+#[cfg(feature = "protobuf-legacy")]
+mod protobuf_legacy_value;
+
+#[cfg(feature = "protobuf")]
+mod protobuf_value;
+
 /// Derive macro for creating opaque types for cxx-cel.
 ///
 /// # Attributes
@@ -28,12 +37,88 @@ mod symbol;
 ///     email: String,
 /// }
 /// ```
-/// 
+///
 ///
 #[proc_macro_derive(Opaque, attributes(cel_cxx))]
 pub fn derive_opaque(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
     opaque::expand_derive_opaque(input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+/// Derive macro for prost-generated protobuf types.
+///
+/// Generates `TypedValue`, `IntoValue`, `FromValue`, `From<T>` for `Value`,
+/// and `TryFrom<Value>` implementations using prost serialization.
+///
+/// # Requirements
+///
+/// The type must implement `prost::Message` and `prost::Name`.
+///
+/// # Attributes
+/// - `type_name = "..."`: Override the protobuf type name (default: `prost::Name::full_name()`).
+/// - `crate = ...`: Custom path to the cel_cxx crate.
+///
+/// # Example
+///
+/// ```ignore
+/// #[derive(Clone, PartialEq, prost::Message, cel_cxx::ProstValue)]
+/// pub struct MyMessage {
+///     #[prost(string, tag = "1")]
+///     pub name: String,
+/// }
+/// ```
+#[cfg(feature = "prost")]
+#[proc_macro_derive(ProstValue, attributes(cel_cxx))]
+pub fn derive_prost_value(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+    prost_value::expand_derive_prost_value(input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+/// Derive macro for protobuf v3 (stepancheg) generated types.
+///
+/// Generates `TypedValue`, `IntoValue`, `FromValue`, `From<T>` for `Value`,
+/// and `TryFrom<Value>` implementations using protobuf v3 serialization.
+///
+/// # Requirements
+///
+/// The type must implement `protobuf::MessageFull`.
+///
+/// # Attributes
+/// - `type_name = "..."`: Override the protobuf type name (default: from descriptor).
+/// - `crate = ...`: Custom path to the cel_cxx crate.
+///
+/// # Example
+///
+/// ```ignore
+/// // On a protobuf-codegen generated type:
+/// #[derive(cel_cxx::ProtobufLegacyValue)]
+/// pub struct MyMessage { ... }
+/// ```
+#[cfg(feature = "protobuf-legacy")]
+#[proc_macro_derive(ProtobufLegacyValue, attributes(cel_cxx))]
+pub fn derive_protobuf_legacy_value(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+    protobuf_legacy_value::expand_derive_protobuf_legacy_value(input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+/// Derive macro for protobuf v4 (cpp kernel) types — **stub, not yet implemented**.
+///
+/// All generated methods will panic with `unimplemented!()`.
+///
+/// # Attributes
+/// - `type_name = "..."`: **Required.** The fully-qualified protobuf type name.
+/// - `crate = ...`: Custom path to the cel_cxx crate.
+#[cfg(feature = "protobuf")]
+#[proc_macro_derive(ProtobufValue, attributes(cel_cxx))]
+pub fn derive_protobuf_value(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+    protobuf_value::expand_derive_protobuf_value(input)
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()
 }

--- a/crates/cel-cxx-macros/src/lib.rs
+++ b/crates/cel-cxx-macros/src/lib.rs
@@ -55,19 +55,23 @@ pub fn derive_opaque(input: TokenStream) -> TokenStream {
 /// # Requirements
 ///
 /// The type must implement `prost::Message` and `prost::Name`.
+/// Enable `prost::Name` generation via `.enable_type_names()` in prost-build.
 ///
 /// # Attributes
 /// - `type_name = "..."`: Override the protobuf type name (default: `prost::Name::full_name()`).
 /// - `crate = ...`: Custom path to the cel_cxx crate.
 ///
-/// # Example
+/// # Setup
 ///
-/// ```ignore
-/// #[derive(Clone, PartialEq, prost::Message, cel_cxx::ProstValue)]
-/// pub struct MyMessage {
-///     #[prost(string, tag = "1")]
-///     pub name: String,
-/// }
+/// In your `build.rs`, inject the derive via `type_attribute()`:
+///
+/// ```rust,ignore
+/// // build.rs
+/// prost_build::Config::new()
+///     .enable_type_names()
+///     .type_attribute("my.package.MyMessage", "#[derive(::cel_cxx::ProstValue)]")
+///     .compile_protos(&["proto/my.proto"], &["proto/"])
+///     .unwrap();
 /// ```
 #[cfg(feature = "prost")]
 #[proc_macro_derive(ProstValue, attributes(cel_cxx))]
@@ -91,12 +95,31 @@ pub fn derive_prost_value(input: TokenStream) -> TokenStream {
 /// - `type_name = "..."`: Override the protobuf type name (default: from descriptor).
 /// - `crate = ...`: Custom path to the cel_cxx crate.
 ///
-/// # Example
+/// # Setup
 ///
-/// ```ignore
-/// // On a protobuf-codegen generated type:
-/// #[derive(cel_cxx::ProtobufLegacyValue)]
-/// pub struct MyMessage { ... }
+/// In your `build.rs`, inject the derive via `customize_callback()`:
+///
+/// ```rust,ignore
+/// // build.rs
+/// use protobuf::reflect::MessageDescriptor;
+/// use protobuf_codegen::{Codegen, Customize, CustomizeCallback};
+///
+/// struct DeriveProtobufLegacyValue;
+///
+/// impl CustomizeCallback for DeriveProtobufLegacyValue {
+///     fn message(&self, _message: &MessageDescriptor) -> Customize {
+///         Customize::default().before("#[derive(::cel_cxx::ProtobufLegacyValue)]")
+///     }
+/// }
+///
+/// fn main() {
+///     Codegen::new()
+///         .cargo_out_dir("protos")
+///         .input("proto/my.proto")
+///         .include("proto/")
+///         .customize_callback(DeriveProtobufLegacyValue)
+///         .run_from_script();
+/// }
 /// ```
 #[cfg(feature = "protobuf-legacy")]
 #[proc_macro_derive(ProtobufLegacyValue, attributes(cel_cxx))]

--- a/crates/cel-cxx-macros/src/prost_value.rs
+++ b/crates/cel-cxx-macros/src/prost_value.rs
@@ -1,0 +1,148 @@
+use crate::symbol::*;
+use proc_macro2::TokenStream;
+use quote::quote;
+
+pub fn expand_derive_prost_value(input: syn::DeriveInput) -> syn::Result<TokenStream> {
+    let ast = Ast::from_ast(&input)?;
+    let tokens = [
+        impl_typed_value(&ast),
+        impl_into_value(&ast),
+        impl_from_value(&ast),
+    ]
+    .into_iter()
+    .collect();
+    Ok(tokens)
+}
+
+struct Ast {
+    ident: syn::Ident,
+    cel_path: syn::Path,
+    type_name_override: Option<syn::LitStr>,
+}
+
+impl Ast {
+    fn from_ast(input: &syn::DeriveInput) -> syn::Result<Self> {
+        if let Some(param) = input.generics.params.first() {
+            return Err(syn::Error::new_spanned(
+                param,
+                "ProstValue cannot be derived for generic types",
+            ));
+        }
+
+        let mut cel_path = None;
+        let mut type_name_override = None;
+
+        for attr in &input.attrs {
+            if !attr.path().is_ident(CEL_CXX) {
+                continue;
+            }
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident(CRATE) {
+                    let path: syn::Path = meta.value()?.parse()?;
+                    cel_path = Some(path);
+                } else if meta.path.is_ident(TYPE_NAME) {
+                    let lit: syn::LitStr = meta.value()?.parse()?;
+                    type_name_override = Some(lit);
+                } else {
+                    return Err(syn::Error::new_spanned(meta.path, "unknown attribute"));
+                }
+                Ok(())
+            })?;
+        }
+
+        let cel_path =
+            cel_path.unwrap_or_else(|| syn::parse_str(&format!("::{CEL_CXX}")).unwrap());
+
+        Ok(Self {
+            ident: input.ident.clone(),
+            cel_path,
+            type_name_override,
+        })
+    }
+
+    fn type_name_expr(&self) -> TokenStream {
+        if let Some(ref lit) = self.type_name_override {
+            quote! { #lit.to_string() }
+        } else {
+            quote! { <Self as ::prost::Name>::full_name() }
+        }
+    }
+}
+
+fn impl_typed_value(ast: &Ast) -> TokenStream {
+    let name = &ast.ident;
+    let cel = &ast.cel_path;
+    let type_name_expr = ast.type_name_expr();
+
+    quote! {
+        impl #cel::values::TypedValue for #name {
+            fn value_type() -> #cel::types::ValueType {
+                #cel::types::ValueType::Struct(#cel::types::StructType::new(#type_name_expr))
+            }
+        }
+    }
+}
+
+fn impl_into_value(ast: &Ast) -> TokenStream {
+    let name = &ast.ident;
+    let cel = &ast.cel_path;
+    let type_name_expr = ast.type_name_expr();
+
+    quote! {
+        impl #cel::values::IntoValue for #name {
+            fn into_value(self) -> #cel::values::Value {
+                use ::prost::Message as _;
+                let type_name = #type_name_expr;
+                let bytes = self.encode_to_vec();
+                #cel::values::Value::Struct(
+                    #cel::values::StructValue::from_bytes(type_name, bytes),
+                )
+            }
+        }
+
+        impl ::std::convert::From<#name> for #cel::values::Value {
+            fn from(value: #name) -> Self {
+                <#name as #cel::values::IntoValue>::into_value(value)
+            }
+        }
+    }
+}
+
+fn impl_from_value(ast: &Ast) -> TokenStream {
+    let name = &ast.ident;
+    let cel = &ast.cel_path;
+
+    quote! {
+        impl #cel::values::FromValue for #name {
+            type Output<'a> = #name;
+
+            fn from_value<'a>(
+                value: &'a #cel::values::Value,
+            ) -> ::std::result::Result<Self::Output<'a>, #cel::values::FromValueError> {
+                match value {
+                    #cel::values::Value::Struct(sv) => {
+                        use ::prost::Message as _;
+                        <#name>::decode(sv.to_bytes()).map_err(|_| {
+                            #cel::values::FromValueError::new_typed::<#name>(value.clone())
+                        })
+                    }
+                    _ => Err(#cel::values::FromValueError::new_typed::<#name>(value.clone())),
+                }
+            }
+        }
+
+        impl ::std::convert::TryFrom<#cel::values::Value> for #name {
+            type Error = #cel::values::FromValueError;
+            fn try_from(value: #cel::values::Value) -> ::std::result::Result<Self, Self::Error> {
+                <Self as #cel::values::FromValue>::from_value(&value)
+            }
+        }
+
+        impl ::std::convert::TryFrom<&#cel::values::Value> for #name {
+            type Error = #cel::values::FromValueError;
+            fn try_from(value: &#cel::values::Value) -> ::std::result::Result<Self, Self::Error> {
+                <Self as #cel::values::FromValue>::from_value(value)
+            }
+        }
+    }
+}

--- a/crates/cel-cxx-macros/src/protobuf_legacy_value.rs
+++ b/crates/cel-cxx-macros/src/protobuf_legacy_value.rs
@@ -1,0 +1,151 @@
+use crate::symbol::*;
+use proc_macro2::TokenStream;
+use quote::quote;
+
+pub fn expand_derive_protobuf_legacy_value(input: syn::DeriveInput) -> syn::Result<TokenStream> {
+    let ast = Ast::from_ast(&input)?;
+    let tokens = [
+        impl_typed_value(&ast),
+        impl_into_value(&ast),
+        impl_from_value(&ast),
+    ]
+    .into_iter()
+    .collect();
+    Ok(tokens)
+}
+
+struct Ast {
+    ident: syn::Ident,
+    cel_path: syn::Path,
+    type_name_override: Option<syn::LitStr>,
+}
+
+impl Ast {
+    fn from_ast(input: &syn::DeriveInput) -> syn::Result<Self> {
+        if let Some(param) = input.generics.params.first() {
+            return Err(syn::Error::new_spanned(
+                param,
+                "ProtobufLegacyValue cannot be derived for generic types",
+            ));
+        }
+
+        let mut cel_path = None;
+        let mut type_name_override = None;
+
+        for attr in &input.attrs {
+            if !attr.path().is_ident(CEL_CXX) {
+                continue;
+            }
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident(CRATE) {
+                    let path: syn::Path = meta.value()?.parse()?;
+                    cel_path = Some(path);
+                } else if meta.path.is_ident(TYPE_NAME) {
+                    let lit: syn::LitStr = meta.value()?.parse()?;
+                    type_name_override = Some(lit);
+                } else {
+                    return Err(syn::Error::new_spanned(meta.path, "unknown attribute"));
+                }
+                Ok(())
+            })?;
+        }
+
+        let cel_path =
+            cel_path.unwrap_or_else(|| syn::parse_str(&format!("::{CEL_CXX}")).unwrap());
+
+        Ok(Self {
+            ident: input.ident.clone(),
+            cel_path,
+            type_name_override,
+        })
+    }
+
+    fn type_name_expr(&self) -> TokenStream {
+        if let Some(ref lit) = self.type_name_override {
+            quote! { #lit.to_string() }
+        } else {
+            quote! {
+                <Self as ::protobuf::MessageFull>::descriptor()
+                    .full_name()
+                    .to_string()
+            }
+        }
+    }
+}
+
+fn impl_typed_value(ast: &Ast) -> TokenStream {
+    let name = &ast.ident;
+    let cel = &ast.cel_path;
+    let type_name_expr = ast.type_name_expr();
+
+    quote! {
+        impl #cel::values::TypedValue for #name {
+            fn value_type() -> #cel::types::ValueType {
+                #cel::types::ValueType::Struct(#cel::types::StructType::new(#type_name_expr))
+            }
+        }
+    }
+}
+
+fn impl_into_value(ast: &Ast) -> TokenStream {
+    let name = &ast.ident;
+    let cel = &ast.cel_path;
+    let type_name_expr = ast.type_name_expr();
+
+    quote! {
+        impl #cel::values::IntoValue for #name {
+            fn into_value(self) -> #cel::values::Value {
+                let type_name = #type_name_expr;
+                let bytes = ::protobuf::Message::write_to_bytes(&self)
+                    .expect("failed to serialize protobuf message");
+                #cel::values::Value::Struct(
+                    #cel::values::StructValue::from_bytes(type_name, bytes),
+                )
+            }
+        }
+
+        impl ::std::convert::From<#name> for #cel::values::Value {
+            fn from(value: #name) -> Self {
+                <#name as #cel::values::IntoValue>::into_value(value)
+            }
+        }
+    }
+}
+
+fn impl_from_value(ast: &Ast) -> TokenStream {
+    let name = &ast.ident;
+    let cel = &ast.cel_path;
+
+    quote! {
+        impl #cel::values::FromValue for #name {
+            type Output<'a> = #name;
+
+            fn from_value<'a>(
+                value: &'a #cel::values::Value,
+            ) -> ::std::result::Result<Self::Output<'a>, #cel::values::FromValueError> {
+                match value {
+                    #cel::values::Value::Struct(sv) => {
+                        ::protobuf::Message::parse_from_bytes(sv.to_bytes()).map_err(|_| {
+                            #cel::values::FromValueError::new_typed::<#name>(value.clone())
+                        })
+                    }
+                    _ => Err(#cel::values::FromValueError::new_typed::<#name>(value.clone())),
+                }
+            }
+        }
+
+        impl ::std::convert::TryFrom<#cel::values::Value> for #name {
+            type Error = #cel::values::FromValueError;
+            fn try_from(value: #cel::values::Value) -> ::std::result::Result<Self, Self::Error> {
+                <Self as #cel::values::FromValue>::from_value(&value)
+            }
+        }
+
+        impl ::std::convert::TryFrom<&#cel::values::Value> for #name {
+            type Error = #cel::values::FromValueError;
+            fn try_from(value: &#cel::values::Value) -> ::std::result::Result<Self, Self::Error> {
+                <Self as #cel::values::FromValue>::from_value(value)
+            }
+        }
+    }
+}

--- a/crates/cel-cxx-macros/src/protobuf_value.rs
+++ b/crates/cel-cxx-macros/src/protobuf_value.rs
@@ -1,0 +1,112 @@
+use crate::symbol::*;
+use proc_macro2::TokenStream;
+use quote::quote;
+
+pub fn expand_derive_protobuf_value(input: syn::DeriveInput) -> syn::Result<TokenStream> {
+    let ast = Ast::from_ast(&input)?;
+    Ok(impl_stub(&ast))
+}
+
+struct Ast {
+    ident: syn::Ident,
+    cel_path: syn::Path,
+    type_name: syn::LitStr,
+}
+
+impl Ast {
+    fn from_ast(input: &syn::DeriveInput) -> syn::Result<Self> {
+        if let Some(param) = input.generics.params.first() {
+            return Err(syn::Error::new_spanned(
+                param,
+                "ProtobufValue cannot be derived for generic types",
+            ));
+        }
+
+        let mut cel_path = None;
+        let mut type_name = None;
+
+        for attr in &input.attrs {
+            if !attr.path().is_ident(CEL_CXX) {
+                continue;
+            }
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident(CRATE) {
+                    let path: syn::Path = meta.value()?.parse()?;
+                    cel_path = Some(path);
+                } else if meta.path.is_ident(TYPE_NAME) {
+                    let lit: syn::LitStr = meta.value()?.parse()?;
+                    type_name = Some(lit);
+                } else {
+                    return Err(syn::Error::new_spanned(meta.path, "unknown attribute"));
+                }
+                Ok(())
+            })?;
+        }
+
+        let type_name = type_name.ok_or_else(|| {
+            syn::Error::new_spanned(
+                &input.ident,
+                "ProtobufValue requires #[cel_cxx(type_name = \"...\")] attribute",
+            )
+        })?;
+
+        let cel_path =
+            cel_path.unwrap_or_else(|| syn::parse_str(&format!("::{CEL_CXX}")).unwrap());
+
+        Ok(Self {
+            ident: input.ident.clone(),
+            cel_path,
+            type_name,
+        })
+    }
+}
+
+fn impl_stub(ast: &Ast) -> TokenStream {
+    let name = &ast.ident;
+    let cel = &ast.cel_path;
+    let type_name = &ast.type_name;
+
+    quote! {
+        impl #cel::values::TypedValue for #name {
+            fn value_type() -> #cel::types::ValueType {
+                #cel::types::ValueType::Struct(#cel::types::StructType::new(#type_name))
+            }
+        }
+
+        impl #cel::values::IntoValue for #name {
+            fn into_value(self) -> #cel::values::Value {
+                unimplemented!("protobuf v4 cpp kernel support is not yet available")
+            }
+        }
+
+        impl ::std::convert::From<#name> for #cel::values::Value {
+            fn from(_value: #name) -> Self {
+                unimplemented!("protobuf v4 cpp kernel support is not yet available")
+            }
+        }
+
+        impl #cel::values::FromValue for #name {
+            type Output<'a> = #name;
+
+            fn from_value<'a>(
+                _value: &'a #cel::values::Value,
+            ) -> ::std::result::Result<Self::Output<'a>, #cel::values::FromValueError> {
+                unimplemented!("protobuf v4 cpp kernel support is not yet available")
+            }
+        }
+
+        impl ::std::convert::TryFrom<#cel::values::Value> for #name {
+            type Error = #cel::values::FromValueError;
+            fn try_from(_value: #cel::values::Value) -> ::std::result::Result<Self, Self::Error> {
+                unimplemented!("protobuf v4 cpp kernel support is not yet available")
+            }
+        }
+
+        impl ::std::convert::TryFrom<&#cel::values::Value> for #name {
+            type Error = #cel::values::FromValueError;
+            fn try_from(_value: &#cel::values::Value) -> ::std::result::Result<Self, Self::Error> {
+                unimplemented!("protobuf v4 cpp kernel support is not yet available")
+            }
+        }
+    }
+}

--- a/crates/cel-cxx-macros/src/symbol.rs
+++ b/crates/cel-cxx-macros/src/symbol.rs
@@ -1,4 +1,6 @@
 pub(crate) const CEL_CXX: &str = "cel_cxx";
 pub(crate) const TYPE: &str = "type";
+#[cfg(any(feature = "prost", feature = "protobuf-legacy", feature = "protobuf"))]
+pub(crate) const TYPE_NAME: &str = "type_name";
 pub(crate) const CRATE: &str = "crate";
 pub(crate) const DISPLAY: &str = "display";

--- a/docs/README.md
+++ b/docs/README.md
@@ -122,6 +122,9 @@ let env = Env::builder()
 | Feature | Description | Default |
 |---------|-------------|---------|
 | `derive` | Derive macros for custom types (`#[derive(Opaque)]`) | ✅ |
+| `prost` | `#[derive(ProstValue)]` for [prost](https://crates.io/crates/prost) protobuf types | ❌ |
+| `protobuf-legacy` | `#[derive(ProtobufLegacyValue)]` for [protobuf](https://crates.io/crates/protobuf) v3 types | ❌ |
+| `protobuf` | `#[derive(ProtobufValue)]` for protobuf v4 types (stub, not yet implemented) | ❌ |
 | `async` | Async/await support for expressions and functions | ❌ |
 | `tokio` | Tokio async runtime integration (requires `async`) | ❌ |
 | `smol` | smol runtime integration (requires `async`) | ❌ |
@@ -156,6 +159,11 @@ cargo run --example tokio --features="tokio"
 
 Comprehensive guide to zero-annotation function registration using Generic Associated Types (GATs).
 Learn how to register functions with owned types, reference types, async functions, and more.
+
+### [Protobuf Derive Macros](protobuf-derive.md)
+
+Setup and usage guide for `#[derive(ProstValue)]` and `#[derive(ProtobufLegacyValue)]`,
+enabling the typed API for protobuf-generated message types.
 
 ### [Advanced Features](advanced-features.md)
 

--- a/docs/protobuf-derive.md
+++ b/docs/protobuf-derive.md
@@ -1,0 +1,195 @@
+# Protobuf Derive Macros
+
+cel-cxx provides derive macros that generate `TypedValue`, `IntoValue`, and `FromValue`
+implementations for protobuf-generated Rust types. This enables the standard typed API
+(`declare_variable::<T>()`, `bind_variable("x", msg)`, `T::from_value(&result)`) instead
+of the lower-level dynamic API (`declare_variable_with_type`, `bind_variable_dynamic`,
+`StructValue::from_bytes`).
+
+## Feature Flags
+
+| Feature | Derive Macro | Protobuf Crate | Status |
+|---------|-------------|----------------|--------|
+| `prost` | `#[derive(ProstValue)]` | [prost](https://crates.io/crates/prost) | Fully supported |
+| `protobuf-legacy` | `#[derive(ProtobufLegacyValue)]` | [protobuf](https://crates.io/crates/protobuf) v3 (stepancheg) | Fully supported |
+| `protobuf` | `#[derive(ProtobufValue)]` | protobuf v4 (cpp kernel) | Stub (not yet implemented) |
+
+Enable the feature matching your protobuf library:
+
+```toml
+[dependencies]
+cel-cxx = { version = "0.2", features = ["prost"] }
+# or
+cel-cxx = { version = "0.2", features = ["protobuf-legacy"] }
+```
+
+## Setup
+
+The derive macros are injected during protobuf code generation in your `build.rs`.
+Both backends support this with minimal configuration.
+
+### prost
+
+**Dependencies:**
+
+```toml
+[dependencies]
+cel-cxx = { version = "0.2", features = ["prost"] }
+prost = "0.14"
+
+[build-dependencies]
+prost-build = "0.14"
+```
+
+**build.rs:**
+
+```rust
+fn main() {
+    prost_build::Config::new()
+        .enable_type_names()  // required: generates prost::Name impls
+        .type_attribute("my.package.MyMessage", "#[derive(::cel_cxx::ProstValue)]")
+        .type_attribute("my.package.Address", "#[derive(::cel_cxx::ProstValue)]")
+        .compile_protos(&["proto/my_service.proto"], &["proto/"])
+        .unwrap();
+}
+```
+
+The key points:
+- `.enable_type_names()` is required -- `ProstValue` uses `prost::Name::full_name()` to
+  derive the protobuf type name.
+- `.type_attribute()` injects the derive on specific message types. You can also use
+  `"."` as the path to apply it to all types.
+
+### protobuf-legacy (stepancheg v3)
+
+**Dependencies:**
+
+```toml
+[dependencies]
+cel-cxx = { version = "0.2", features = ["protobuf-legacy"] }
+protobuf = "3"
+
+[build-dependencies]
+protobuf = "3"
+protobuf-codegen = "3"
+```
+
+**build.rs:**
+
+```rust
+use protobuf::reflect::MessageDescriptor;
+use protobuf_codegen::{Codegen, Customize, CustomizeCallback};
+
+struct DeriveProtobufLegacyValue;
+
+impl CustomizeCallback for DeriveProtobufLegacyValue {
+    fn message(&self, _message: &MessageDescriptor) -> Customize {
+        Customize::default().before("#[derive(::cel_cxx::ProtobufLegacyValue)]")
+    }
+}
+
+fn main() {
+    Codegen::new()
+        .cargo_out_dir("protos")
+        .input("proto/my_service.proto")
+        .include("proto/")
+        .customize_callback(DeriveProtobufLegacyValue)
+        .run_from_script();
+}
+```
+
+The `customize_callback` API injects arbitrary attributes before generated items.
+The callback receives a `MessageDescriptor`, so you can selectively derive on
+specific messages if needed.
+
+## Usage
+
+Once the derives are in place, protobuf types integrate with the standard cel-cxx API:
+
+```rust,ignore
+use cel_cxx::*;
+
+// Include the generated types
+include!(concat!(env!("OUT_DIR"), "/my.package.rs"));  // prost
+// or
+// include!(concat!(env!("OUT_DIR"), "/protos/my_service.rs"));  // protobuf-legacy
+
+// 1. Compile descriptors (needed by cel-cpp at runtime)
+let descriptors: Vec<u8> = { /* protox::compile(...) or include_bytes!(...) */ };
+
+// 2. Build environment with typed declarations
+let env = Env::builder()
+    .with_file_descriptor_set(&descriptors)
+    .declare_variable::<MyMessage>("msg")?
+    .build()?;
+
+// 3. Compile and evaluate
+let program = env.compile("msg.name == 'Alice' && msg.id > 0")?;
+
+let msg = MyMessage {
+    name: "Alice".into(),
+    id: 42,
+    ..Default::default()
+};
+
+let activation = Activation::new().bind_variable("msg", msg)?;
+let result = program.evaluate(&activation)?;
+assert_eq!(result, Value::Bool(true));
+```
+
+### Round-trip: Rust -> CEL -> Rust
+
+```rust,ignore
+// CEL can construct messages using Type{field: value} syntax
+let program = env.compile("my.package.MyMessage{name: 'Bob', id: 99}")?;
+let result = program.evaluate(&Activation::new())?;
+
+// Recover the Rust type from the CEL result
+let recovered = MyMessage::from_value(&result)?;
+assert_eq!(recovered.name, "Bob");
+assert_eq!(recovered.id, 99);
+
+// TryFrom<Value> also works
+let recovered: MyMessage = result.try_into()?;
+```
+
+## Attributes
+
+Both `ProstValue` and `ProtobufLegacyValue` support the `#[cel_cxx(...)]` attribute:
+
+| Attribute | Description | Default |
+|-----------|-------------|---------|
+| `type_name = "..."` | Override the protobuf fully-qualified type name | Derived from the protobuf library |
+| `crate = ...` | Custom path to the cel_cxx crate | `::cel_cxx` |
+
+Example:
+
+```rust,ignore
+#[derive(ProstValue)]
+#[cel_cxx(type_name = "custom.package.MyType")]
+pub struct MyMessage { /* ... */ }
+```
+
+## How It Works
+
+The derive macros generate implementations based on serialization:
+
+1. **`TypedValue`** -- returns `ValueType::Struct(StructType::new(full_name))` where the
+   full name comes from the protobuf library (`prost::Name::full_name()` or
+   `protobuf::MessageFull::descriptor().full_name()`).
+
+2. **`IntoValue`** -- serializes the message to bytes and wraps it in a
+   `StructValue::from_bytes(type_name, bytes)`.
+
+3. **`FromValue`** -- extracts the bytes from a `StructValue` and deserializes back
+   to the Rust type.
+
+This means messages cross the Rust/C++ FFI boundary via serialization. See the
+[Performance Note](../README.md#performance-note) in the main README for details.
+
+## Limitations
+
+- Generic types are not supported (the derive macro will emit a compile error).
+- The `protobuf` feature (v4 cpp kernel) is a stub -- all methods panic with
+  `unimplemented!()`. This will be implemented when the Rust protobuf v4 ecosystem
+  stabilizes.

--- a/examples/protobuf-advanced.rs
+++ b/examples/protobuf-advanced.rs
@@ -1,0 +1,544 @@
+//! Advanced protobuf example: nested messages, repeated fields, maps, WKTs, and more
+//!
+//! This example builds on the basic protobuf example to demonstrate:
+//! - Deeply nested messages (Order -> Person -> Address)
+//! - Repeated message fields (Order.items)
+//! - Map fields (Order.labels)
+//! - Enums (Person.status)
+//! - Well-Known Types: Duration, Timestamp, wrappers (Int64Value, StringValue, BoolValue)
+//! - `google.protobuf.Struct` as a dynamic map
+//! - Field presence checks with `has()`
+//! - Type checks with `type()`
+//! - CEL comprehensions (`.filter()`, `.map()`, `.exists()`, `.all()`)
+//! - Message construction with `Type{field: value}` syntax
+//! - Rust-side field extraction from nested results
+//!
+//! Run with: `cargo run --example protobuf-advanced`
+
+use cel_cxx::*;
+
+fn compile_descriptors() -> Vec<u8> {
+    use prost::Message;
+    protox::compile(["tests/fixtures/test.proto"], ["tests/fixtures/"])
+        .expect("failed to compile test.proto")
+        .encode_to_vec()
+}
+
+// =============================================================================
+// Protobuf encoding helpers (using prost's low-level encoding)
+//
+// In a real application you would use generated prost structs or protobuf
+// message types.  Here we encode by hand so the example has no codegen step.
+// =============================================================================
+
+mod proto {
+    use prost::encoding::*;
+
+    // -- primitive field encoders -------------------------------------------
+
+    pub fn string(buf: &mut Vec<u8>, field: u32, v: &str) {
+        if !v.is_empty() {
+            encode_key(field, WireType::LengthDelimited, buf);
+            encode_varint(v.len() as u64, buf);
+            buf.extend_from_slice(v.as_bytes());
+        }
+    }
+
+    pub fn int32(buf: &mut Vec<u8>, field: u32, v: i32) {
+        if v != 0 {
+            encode_key(field, WireType::Varint, buf);
+            encode_varint(v as i64 as u64, buf);
+        }
+    }
+
+    pub fn int64(buf: &mut Vec<u8>, field: u32, v: i64) {
+        if v != 0 {
+            encode_key(field, WireType::Varint, buf);
+            #[allow(clippy::cast_sign_loss)]
+            encode_varint(v as u64, buf);
+        }
+    }
+
+    pub fn bool_(buf: &mut Vec<u8>, field: u32, v: bool) {
+        if v {
+            encode_key(field, WireType::Varint, buf);
+            encode_varint(1, buf);
+        }
+    }
+
+    pub fn nested(buf: &mut Vec<u8>, field: u32, msg: &[u8]) {
+        if !msg.is_empty() {
+            encode_key(field, WireType::LengthDelimited, buf);
+            encode_varint(msg.len() as u64, buf);
+            buf.extend_from_slice(msg);
+        }
+    }
+
+    pub fn repeated_nested(buf: &mut Vec<u8>, field: u32, items: &[Vec<u8>]) {
+        for item in items {
+            nested(buf, field, item);
+        }
+    }
+
+    pub fn map_string_string(buf: &mut Vec<u8>, field: u32, entries: &[(&str, &str)]) {
+        for (k, v) in entries {
+            let mut entry = Vec::new();
+            string(&mut entry, 1, k);
+            string(&mut entry, 2, v);
+            nested(buf, field, &entry);
+        }
+    }
+
+    // -- message encoders ---------------------------------------------------
+
+    /// test.Address { street, city, zip }
+    pub fn address(street: &str, city: &str, zip: &str) -> Vec<u8> {
+        let mut buf = Vec::new();
+        string(&mut buf, 1, street);
+        string(&mut buf, 2, city);
+        string(&mut buf, 3, zip);
+        buf
+    }
+
+    /// test.Person { name, age, address, status, tags, active }
+    pub fn person(
+        name: &str,
+        age: i32,
+        addr: Option<&[u8]>,
+        status: i32,
+        tags: &[&str],
+        active: bool,
+    ) -> Vec<u8> {
+        let mut buf = Vec::new();
+        string(&mut buf, 1, name);
+        int32(&mut buf, 2, age);
+        if let Some(a) = addr {
+            nested(&mut buf, 3, a);
+        }
+        int32(&mut buf, 4, status);
+        for t in tags {
+            string(&mut buf, 5, t);
+        }
+        bool_(&mut buf, 6, active);
+        buf
+    }
+
+    /// test.Item { name, price }
+    pub fn item(name: &str, price: i32) -> Vec<u8> {
+        let mut buf = Vec::new();
+        string(&mut buf, 1, name);
+        int32(&mut buf, 2, price);
+        buf
+    }
+
+    /// test.Order { buyer, items, labels }
+    pub fn order(buyer: &[u8], items: &[Vec<u8>], labels: &[(&str, &str)]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        nested(&mut buf, 1, buyer);
+        repeated_nested(&mut buf, 2, items);
+        map_string_string(&mut buf, 3, labels);
+        buf
+    }
+
+    // -- WKT encoders -------------------------------------------------------
+
+    /// google.protobuf.Duration { seconds, nanos }
+    pub fn duration(seconds: i64, nanos: i32) -> Vec<u8> {
+        let mut buf = Vec::new();
+        int64(&mut buf, 1, seconds);
+        int32(&mut buf, 2, nanos);
+        buf
+    }
+
+    /// google.protobuf.Timestamp { seconds, nanos }
+    pub fn timestamp(seconds: i64, nanos: i32) -> Vec<u8> {
+        let mut buf = Vec::new();
+        int64(&mut buf, 1, seconds);
+        int32(&mut buf, 2, nanos);
+        buf
+    }
+
+    /// google.protobuf.Int64Value { value }
+    pub fn int64_value(v: i64) -> Vec<u8> {
+        let mut buf = Vec::new();
+        int64(&mut buf, 1, v);
+        buf
+    }
+
+    /// google.protobuf.StringValue { value }
+    pub fn string_value(v: &str) -> Vec<u8> {
+        let mut buf = Vec::new();
+        string(&mut buf, 1, v);
+        buf
+    }
+
+    /// google.protobuf.BoolValue { value }
+    pub fn bool_value(v: bool) -> Vec<u8> {
+        let mut buf = Vec::new();
+        bool_(&mut buf, 1, v);
+        buf
+    }
+
+    /// google.protobuf.Struct with string-typed values
+    pub fn struct_with_strings(entries: &[(&str, &str)]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        for (key, val) in entries {
+            // Value message: field 3 = string_value
+            let mut value_msg = Vec::new();
+            string(&mut value_msg, 3, val);
+            // MapEntry: { 1: key, 2: Value }
+            let mut entry = Vec::new();
+            string(&mut entry, 1, key);
+            nested(&mut entry, 2, &value_msg);
+            // Struct.fields is field 1 (map<string, Value>)
+            nested(&mut buf, 1, &entry);
+        }
+        buf
+    }
+
+    /// test.Event { name, created_at, ttl, optional_count, optional_label,
+    ///              optional_flag, metadata, payload }
+    pub fn event(
+        name: &str,
+        created_at: Option<&[u8]>,
+        ttl: Option<&[u8]>,
+        optional_count: Option<&[u8]>,
+        optional_label: Option<&[u8]>,
+        optional_flag: Option<&[u8]>,
+        metadata: Option<&[u8]>,
+        payload: Option<&[u8]>,
+    ) -> Vec<u8> {
+        let mut buf = Vec::new();
+        string(&mut buf, 1, name);
+        if let Some(v) = created_at {
+            nested(&mut buf, 2, v);
+        }
+        if let Some(v) = ttl {
+            nested(&mut buf, 3, v);
+        }
+        if let Some(v) = optional_count {
+            nested(&mut buf, 4, v);
+        }
+        if let Some(v) = optional_label {
+            nested(&mut buf, 5, v);
+        }
+        if let Some(v) = optional_flag {
+            nested(&mut buf, 6, v);
+        }
+        if let Some(v) = metadata {
+            nested(&mut buf, 7, v);
+        }
+        if let Some(v) = payload {
+            nested(&mut buf, 8, v);
+        }
+        buf
+    }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Compile, evaluate, and print.  Returns the result for further inspection.
+fn eval(env: &Env, activation: &Activation, expr: &str) -> Result<Value, Error> {
+    let program = env.compile(expr)?;
+    let result = program.evaluate(activation)?;
+    println!("  {expr}\n    => {result}");
+    Ok(result)
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+fn main() -> Result<(), Error> {
+    // =========================================================================
+    // 1. Nested messages, enums, repeated fields, maps
+    // =========================================================================
+    println!("=== 1. Complex message: Order with nested Person, Items, and labels ===\n");
+
+    let env = Env::builder()
+        .with_file_descriptor_set(&compile_descriptors())
+        .declare_protobuf_variable("order", "test.Order")?
+        // CEL has no built-in reduce/fold, so register helpers for aggregation
+        .register_global_function("sum_ints", |v: Vec<i64>| -> i64 { v.iter().sum() })?
+        .build()?;
+
+    // Build a realistic Order
+    let addr = proto::address("123 Main St", "Springfield", "62704");
+    let buyer = proto::person(
+        "Alice",
+        30,
+        Some(&addr),
+        1, // STATUS_ACTIVE
+        &["vip", "early-adopter"],
+        true,
+    );
+    let items = vec![
+        proto::item("Widget", 1299),    // $12.99 in cents
+        proto::item("Gadget", 4599),     // $45.99
+        proto::item("Doohickey", 299),   // $2.99
+        proto::item("Thingamajig", 999), // $9.99
+    ];
+    let labels = [("priority", "high"), ("region", "us-west"), ("channel", "web")];
+
+    let order_bytes = proto::order(&buyer, &items, &labels);
+    let activation = Activation::new()
+        .bind_protobuf_variable("order", "test.Order", &order_bytes)?;
+
+    // Deep field access
+    eval(&env, &activation, "order.buyer.name")?;
+    eval(&env, &activation, "order.buyer.address.city")?;
+    eval(&env, &activation, "order.buyer.address.zip")?;
+    eval(&env, &activation, "order.buyer.active")?;
+
+    // Enum
+    eval(&env, &activation, "order.buyer.status == 1")?;
+    eval(
+        &env,
+        &activation,
+        "order.buyer.status == test.Status.STATUS_ACTIVE",
+    )?;
+
+    // Repeated string field
+    eval(&env, &activation, "order.buyer.tags")?;
+    eval(&env, &activation, "'vip' in order.buyer.tags")?;
+
+    // Repeated message field
+    eval(&env, &activation, "order.items.size()")?;
+    eval(&env, &activation, "order.items[0].name")?;
+    eval(&env, &activation, "order.items[1].price")?;
+
+    // Map field
+    eval(&env, &activation, "order.labels")?;
+    eval(&env, &activation, "order.labels['priority']")?;
+    eval(&env, &activation, "'region' in order.labels")?;
+
+    // =========================================================================
+    // 2. CEL comprehensions on repeated message fields
+    // =========================================================================
+    println!("\n=== 2. Comprehensions: filter, map, exists, all ===\n");
+
+    // Filter items by price
+    eval(
+        &env,
+        &activation,
+        "order.items.filter(i, i.price > 1000)",
+    )?;
+    eval(
+        &env,
+        &activation,
+        "order.items.filter(i, i.price > 1000).size()",
+    )?;
+
+    // Map: extract names of expensive items
+    eval(
+        &env,
+        &activation,
+        "order.items.filter(i, i.price >= 4000).map(i, i.name)",
+    )?;
+
+    // Exists: is there an item over $40?
+    eval(
+        &env,
+        &activation,
+        "order.items.exists(i, i.price > 4000)",
+    )?;
+
+    // All: are all items under $100?
+    eval(
+        &env,
+        &activation,
+        "order.items.all(i, i.price < 10000)",
+    )?;
+
+    // CEL has no built-in reduce/fold — use a custom Rust function to aggregate
+    eval(
+        &env,
+        &activation,
+        "sum_ints(order.items.map(i, i.price))",
+    )?;
+
+    // =========================================================================
+    // 3. has() — field presence checks
+    // =========================================================================
+    println!("\n=== 3. has() — field presence checks ===\n");
+
+    eval(&env, &activation, "has(order.buyer)")?;
+    eval(&env, &activation, "has(order.buyer.address)")?;
+    eval(&env, &activation, "has(order.buyer.address.city)")?;
+
+    // Build a minimal order with no address
+    let buyer_no_addr = proto::person("Bob", 25, None, 0, &[], false);
+    let minimal_order = proto::order(&buyer_no_addr, &[], &[]);
+    let activation2 = Activation::new()
+        .bind_protobuf_variable("order", "test.Order", &minimal_order)?;
+
+    eval(&env, &activation2, "has(order.buyer.address)")?;
+    eval(&env, &activation2, "has(order.buyer.address) ? order.buyer.address.city : 'N/A'")?;
+
+    // =========================================================================
+    // 4. type() — runtime type inspection
+    // =========================================================================
+    println!("\n=== 4. type() — runtime type inspection ===\n");
+
+    eval(&env, &activation, "type(order)")?;
+    eval(&env, &activation, "type(order.buyer)")?;
+    eval(&env, &activation, "type(order.buyer.name)")?;
+    eval(&env, &activation, "type(order.items)")?;
+    eval(&env, &activation, "type(order.buyer.active)")?;
+
+    // =========================================================================
+    // 5. Well-Known Types: Duration, Timestamp, wrappers, Struct
+    // =========================================================================
+    println!("\n=== 5. Well-Known Types ===\n");
+
+    let env_event = Env::builder()
+        .with_file_descriptor_set(&compile_descriptors())
+        .declare_protobuf_variable("event", "test.Event")?
+        .build()?;
+
+    let event_bytes = proto::event(
+        "deploy-v2.3",
+        Some(&proto::timestamp(1700000000, 0)), // 2023-11-14T22:13:20Z
+        Some(&proto::duration(3600, 0)),         // 1 hour TTL
+        Some(&proto::int64_value(42)),           // optional_count = 42
+        Some(&proto::string_value("production")),// optional_label = "production"
+        Some(&proto::bool_value(true)),          // optional_flag = true
+        Some(&proto::struct_with_strings(&[     // metadata
+            ("env", "prod"),
+            ("version", "2.3.0"),
+            ("deployer", "ci-bot"),
+        ])),
+        None, // no Any payload
+    );
+
+    let act_event = Activation::new()
+        .bind_protobuf_variable("event", "test.Event", &event_bytes)?;
+
+    // Timestamp — auto-converts to CEL timestamp type
+    eval(&env_event, &act_event, "event.name")?;
+    eval(&env_event, &act_event, "event.created_at")?;
+    eval(
+        &env_event,
+        &act_event,
+        "event.created_at > timestamp('2023-01-01T00:00:00Z')",
+    )?;
+    eval(
+        &env_event,
+        &act_event,
+        "event.created_at.getFullYear()",
+    )?;
+
+    // Duration — auto-converts to CEL duration type
+    eval(&env_event, &act_event, "event.ttl")?;
+    eval(
+        &env_event,
+        &act_event,
+        "event.ttl > duration('30m')",
+    )?;
+    eval(
+        &env_event,
+        &act_event,
+        "event.ttl == duration('1h')",
+    )?;
+
+    // Wrapper types — auto-unbox to CEL primitives
+    eval(&env_event, &act_event, "event.optional_count")?;
+    eval(&env_event, &act_event, "event.optional_count > 10")?;
+    eval(&env_event, &act_event, "event.optional_label")?;
+    eval(
+        &env_event,
+        &act_event,
+        "event.optional_label == 'production'",
+    )?;
+    eval(&env_event, &act_event, "event.optional_flag")?;
+
+    // Struct — behaves as a dynamic map
+    eval(&env_event, &act_event, "event.metadata.env")?;
+    eval(&env_event, &act_event, "event.metadata.version")?;
+    eval(&env_event, &act_event, "has(event.metadata.deployer)")?;
+
+    // has() on wrapper fields — true when set
+    eval(&env_event, &act_event, "has(event.optional_count)")?;
+
+    // Event without optional fields
+    let sparse_event = proto::event("bare-event", None, None, None, None, None, None, None);
+    let act_sparse = Activation::new()
+        .bind_protobuf_variable("event", "test.Event", &sparse_event)?;
+    eval(&env_event, &act_sparse, "has(event.optional_count)")?;
+    eval(&env_event, &act_sparse, "has(event.ttl)")?;
+
+    // =========================================================================
+    // 6. Message construction in CEL
+    // =========================================================================
+    println!("\n=== 6. Message construction in CEL ===\n");
+
+    let env_construct = Env::builder()
+        .with_file_descriptor_set(&compile_descriptors())
+        .build()?;
+    let empty = Activation::new();
+
+    // Simple message
+    eval(
+        &env_construct,
+        &empty,
+        "test.SimpleMessage{name: 'Eve', id: 7}",
+    )?;
+
+    // Nested: Person with inline Address
+    eval(
+        &env_construct,
+        &empty,
+        "test.Person{name: 'Frank', age: 40, address: test.Address{street: '456 Oak Ave', city: 'Portland', zip: '97201'}, active: true}",
+    )?;
+
+    // Order with repeated items
+    eval(
+        &env_construct,
+        &empty,
+        "test.Order{buyer: test.Person{name: 'Grace', age: 28}, items: [test.Item{name: 'Book', price: 1599}, test.Item{name: 'Pen', price: 199}]}",
+    )?;
+
+    // Inline field access on a constructed message
+    eval(
+        &env_construct,
+        &empty,
+        "test.Order{buyer: test.Person{name: 'Grace'}, items: [test.Item{name: 'Book', price: 1599}]}.items[0].name",
+    )?;
+
+    // =========================================================================
+    // 7. Rust-side field extraction from complex results
+    // =========================================================================
+    println!("\n=== 7. Rust-side field extraction ===\n");
+
+    // Evaluate an expression that returns a message
+    let program = env.compile("order.buyer")?;
+    let buyer_result = program.evaluate(&activation)?;
+    let buyer_sv = StructValue::from_value(&buyer_result)?;
+    println!("  Extracted buyer: type={}, {} bytes", buyer_sv.type_name, buyer_sv.bytes.len());
+
+    // Read individual fields from the extracted message
+    let name = env.get_protobuf_field(&buyer_sv, "name")?;
+    let age = env.get_protobuf_field(&buyer_sv, "age")?;
+    let has_addr = env.has_protobuf_field(&buyer_sv, "address")?;
+    println!("  buyer.name  = {name}");
+    println!("  buyer.age   = {age}");
+    println!("  has(buyer.address) = {has_addr}");
+
+    // Extract the nested address
+    let addr_result = env.get_protobuf_field(&buyer_sv, "address")?;
+    let addr_sv = StructValue::from_value(&addr_result)?;
+    let city = env.get_protobuf_field(&addr_sv, "city")?;
+    let zip = env.get_protobuf_field(&addr_sv, "zip")?;
+    println!("  buyer.address.city = {city}");
+    println!("  buyer.address.zip  = {zip}");
+
+    // Extract a repeated field via CEL comprehension
+    let program = env.compile("order.items.map(i, i.name)")?;
+    let names_result = program.evaluate(&activation)?;
+    println!("  item names = {names_result}");
+
+    println!("\nDone.");
+    Ok(())
+}

--- a/examples/protobuf-advanced.rs
+++ b/examples/protobuf-advanced.rs
@@ -67,11 +67,9 @@ mod proto {
     }
 
     pub fn nested(buf: &mut Vec<u8>, field: u32, msg: &[u8]) {
-        if !msg.is_empty() {
-            encode_key(field, WireType::LengthDelimited, buf);
-            encode_varint(msg.len() as u64, buf);
-            buf.extend_from_slice(msg);
-        }
+        encode_key(field, WireType::LengthDelimited, buf);
+        encode_varint(msg.len() as u64, buf);
+        buf.extend_from_slice(msg);
     }
 
     pub fn repeated_nested(buf: &mut Vec<u8>, field: u32, items: &[Vec<u8>]) {
@@ -259,7 +257,7 @@ fn main() -> Result<(), Error> {
 
     let env = Env::builder()
         .with_file_descriptor_set(&compile_descriptors())
-        .declare_protobuf_variable("order", "test.Order")?
+        .declare_variable_with_type("order", ValueType::Struct(StructType::new("test.Order")))?
         // CEL has no built-in reduce/fold, so register helpers for aggregation
         .register_global_function("sum_ints", |v: Vec<i64>| -> i64 { v.iter().sum() })?
         .build()?;
@@ -284,7 +282,7 @@ fn main() -> Result<(), Error> {
 
     let order_bytes = proto::order(&buyer, &items, &labels);
     let activation = Activation::new()
-        .bind_protobuf_variable("order", "test.Order", &order_bytes)?;
+        .bind_variable_dynamic("order", StructValue::from_bytes("test.Order", order_bytes))?;
 
     // Deep field access
     eval(&env, &activation, "order.buyer.name")?;
@@ -372,7 +370,7 @@ fn main() -> Result<(), Error> {
     let buyer_no_addr = proto::person("Bob", 25, None, 0, &[], false);
     let minimal_order = proto::order(&buyer_no_addr, &[], &[]);
     let activation2 = Activation::new()
-        .bind_protobuf_variable("order", "test.Order", &minimal_order)?;
+        .bind_variable_dynamic("order", StructValue::from_bytes("test.Order", minimal_order))?;
 
     eval(&env, &activation2, "has(order.buyer.address)")?;
     eval(&env, &activation2, "has(order.buyer.address) ? order.buyer.address.city : 'N/A'")?;
@@ -395,7 +393,7 @@ fn main() -> Result<(), Error> {
 
     let env_event = Env::builder()
         .with_file_descriptor_set(&compile_descriptors())
-        .declare_protobuf_variable("event", "test.Event")?
+        .declare_variable_with_type("event", ValueType::Struct(StructType::new("test.Event")))?
         .build()?;
 
     let event_bytes = proto::event(
@@ -414,7 +412,7 @@ fn main() -> Result<(), Error> {
     );
 
     let act_event = Activation::new()
-        .bind_protobuf_variable("event", "test.Event", &event_bytes)?;
+        .bind_variable_dynamic("event", StructValue::from_bytes("test.Event", event_bytes))?;
 
     // Timestamp — auto-converts to CEL timestamp type
     eval(&env_event, &act_event, "event.name")?;
@@ -465,7 +463,7 @@ fn main() -> Result<(), Error> {
     // Event without optional fields
     let sparse_event = proto::event("bare-event", None, None, None, None, None, None, None);
     let act_sparse = Activation::new()
-        .bind_protobuf_variable("event", "test.Event", &sparse_event)?;
+        .bind_variable_dynamic("event", StructValue::from_bytes("test.Event", sparse_event))?;
     eval(&env_event, &act_sparse, "has(event.optional_count)")?;
     eval(&env_event, &act_sparse, "has(event.ttl)")?;
 
@@ -516,21 +514,21 @@ fn main() -> Result<(), Error> {
     let program = env.compile("order.buyer")?;
     let buyer_result = program.evaluate(&activation)?;
     let buyer_sv = StructValue::from_value(&buyer_result)?;
-    println!("  Extracted buyer: type={}, {} bytes", buyer_sv.type_name, buyer_sv.bytes.len());
+    println!("  Extracted buyer: type={}, {} bytes", buyer_sv.type_name(), buyer_sv.to_bytes().len());
 
     // Read individual fields from the extracted message
-    let name = env.get_protobuf_field(&buyer_sv, "name")?;
-    let age = env.get_protobuf_field(&buyer_sv, "age")?;
-    let has_addr = env.has_protobuf_field(&buyer_sv, "address")?;
+    let name = env.get_struct_field(&buyer_sv, "name")?;
+    let age = env.get_struct_field(&buyer_sv, "age")?;
+    let has_addr = env.has_struct_field(&buyer_sv, "address")?;
     println!("  buyer.name  = {name}");
     println!("  buyer.age   = {age}");
     println!("  has(buyer.address) = {has_addr}");
 
     // Extract the nested address
-    let addr_result = env.get_protobuf_field(&buyer_sv, "address")?;
+    let addr_result = env.get_struct_field(&buyer_sv, "address")?;
     let addr_sv = StructValue::from_value(&addr_result)?;
-    let city = env.get_protobuf_field(&addr_sv, "city")?;
-    let zip = env.get_protobuf_field(&addr_sv, "zip")?;
+    let city = env.get_struct_field(&addr_sv, "city")?;
+    let zip = env.get_struct_field(&addr_sv, "zip")?;
     println!("  buyer.address.city = {city}");
     println!("  buyer.address.zip  = {zip}");
 

--- a/examples/protobuf-legacy-derive.rs
+++ b/examples/protobuf-legacy-derive.rs
@@ -1,0 +1,85 @@
+//! Example: Using ProtobufLegacyValue derive macro with protobuf-codegen generated types.
+//!
+//! This shows the end-to-end workflow:
+//! 1. Generate Rust types from .proto with `#[derive(ProtobufLegacyValue)]` via protobuf-codegen
+//! 2. Declare typed variables in the CEL environment
+//! 3. Bind protobuf messages directly (no manual serialization)
+//! 4. Evaluate CEL expressions and recover typed results
+//!
+//! Run with: cargo run --example protobuf-legacy-derive --features protobuf-legacy
+
+#![cfg(feature = "protobuf-legacy")]
+
+use cel_cxx::*;
+
+// Import protobuf-codegen generated types (ProtobufLegacyValue derived via build.rs customize_callback)
+#[allow(non_camel_case_types, non_snake_case, non_upper_case_globals, unused_mut)]
+mod proto {
+    include!(concat!(
+        env!("OUT_DIR"),
+        "/protobuf_legacy_gen/test.rs"
+    ));
+}
+use proto::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Compile the FileDescriptorSet for cel-cpp's type system
+    let fds = {
+        use prost::Message;
+        protox::compile(["tests/fixtures/test.proto"], ["tests/fixtures/"])?.encode_to_vec()
+    };
+
+    // 2. Build the environment with typed variable declarations
+    let env = Env::builder()
+        .with_file_descriptor_set(&fds)
+        .declare_variable::<SimpleMessage>("msg")?
+        .declare_variable::<Person>("person")?
+        .build()?;
+
+    // 3. Create protobuf messages (normal protobuf v3 usage)
+    let mut msg = SimpleMessage::new();
+    msg.name = "Hello from protobuf-legacy!".into();
+    msg.id = 42;
+
+    let mut address = Address::new();
+    address.street = "123 Main St".into();
+    address.city = "Wonderland".into();
+    address.zip = "00000".into();
+
+    let mut person = Person::new();
+    person.name = "Alice".into();
+    person.age = 30;
+    person.address = ::protobuf::MessageField::some(address);
+    person.status = proto::Status::STATUS_ACTIVE.into();
+    person.tags = vec!["admin".into(), "user".into()];
+    person.active = true;
+
+    // 4. Bind directly — ProtobufLegacyValue handles serialization
+    let activation = Activation::new()
+        .bind_variable("msg", msg)?
+        .bind_variable("person", person)?;
+
+    // 5. Evaluate field access
+    let program = env.compile("msg.name")?;
+    let result = program.evaluate(&activation)?;
+    println!("msg.name = {result}");
+
+    let program = env.compile("person.address.city")?;
+    let result = program.evaluate(&activation)?;
+    println!("person.address.city = {result}");
+
+    let program = env.compile("person.tags.size()")?;
+    let result = program.evaluate(&activation)?;
+    println!("person.tags.size() = {result}");
+
+    // 6. Construct a message in CEL and recover it as a typed protobuf struct
+    let program = env.compile("test.SimpleMessage{name: 'built in CEL', id: 999}")?;
+    let result = program.evaluate(&Activation::new())?;
+    let recovered = SimpleMessage::from_value(&result)?;
+    println!(
+        "Constructed in CEL: name={}, id={}",
+        recovered.name, recovered.id
+    );
+
+    Ok(())
+}

--- a/examples/protobuf-prost-derive.rs
+++ b/examples/protobuf-prost-derive.rs
@@ -1,0 +1,79 @@
+//! Example: Using ProstValue derive macro with prost-generated protobuf types.
+//!
+//! This shows the end-to-end workflow:
+//! 1. Generate Rust types from .proto with `#[derive(ProstValue)]` via prost-build
+//! 2. Declare typed variables in the CEL environment
+//! 3. Bind prost messages directly (no manual serialization)
+//! 4. Evaluate CEL expressions and recover typed results
+//!
+//! Run with: cargo run --example protobuf-prost-derive --features prost
+
+#![cfg(feature = "prost")]
+
+use cel_cxx::*;
+
+// Import prost-generated types (ProstValue derived via build.rs type_attribute)
+include!(concat!(env!("OUT_DIR"), "/test.rs"));
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Compile the FileDescriptorSet for cel-cpp's type system
+    let fds = {
+        use prost::Message;
+        protox::compile(["tests/fixtures/test.proto"], ["tests/fixtures/"])?.encode_to_vec()
+    };
+
+    // 2. Build the environment with typed variable declarations
+    let env = Env::builder()
+        .with_file_descriptor_set(&fds)
+        .declare_variable::<SimpleMessage>("msg")?
+        .declare_variable::<Person>("person")?
+        .build()?;
+
+    // 3. Create prost messages (normal prost usage)
+    let msg = SimpleMessage {
+        name: "Hello from prost!".into(),
+        id: 42,
+    };
+
+    let person = Person {
+        name: "Alice".into(),
+        age: 30,
+        address: Some(Address {
+            street: "123 Main St".into(),
+            city: "Wonderland".into(),
+            zip: "00000".into(),
+        }),
+        status: Status::Active as i32,
+        tags: vec!["admin".into(), "user".into()],
+        active: true,
+    };
+
+    // 4. Bind directly — ProstValue handles serialization
+    let activation = Activation::new()
+        .bind_variable("msg", msg)?
+        .bind_variable("person", person)?;
+
+    // 5. Evaluate field access
+    let program = env.compile("msg.name")?;
+    let result = program.evaluate(&activation)?;
+    println!("msg.name = {result}");
+
+    let program = env.compile("person.address.city")?;
+    let result = program.evaluate(&activation)?;
+    println!("person.address.city = {result}");
+
+    let program = env.compile("person.tags.size()")?;
+    let result = program.evaluate(&activation)?;
+    println!("person.tags.size() = {result}");
+
+    // 6. Construct a message in CEL and recover it as a typed prost struct
+    let program = env.compile("test.SimpleMessage{name: 'built in CEL', id: 999}")?;
+    let result = program.evaluate(&Activation::new())?;
+    let recovered = SimpleMessage::from_value(&result)?;
+    println!(
+        "Constructed in CEL: name={}, id={}",
+        recovered.name, recovered.id
+    );
+
+    Ok(())
+}

--- a/examples/protobuf.rs
+++ b/examples/protobuf.rs
@@ -1,0 +1,134 @@
+//! Example: Protobuf message integration with CEL expressions
+//!
+//! This example demonstrates the complete protobuf workflow:
+//!
+//! ## Workflow overview
+//!
+//! 1. **Compile** `.proto` files to a `FileDescriptorSet` at runtime using
+//!    [`protox`](https://crates.io/crates/protox) (pure Rust, no external binary needed),
+//!    or offline via `protoc --descriptor_set_out`.
+//!
+//! 2. **Build** an environment with the descriptors and declare protobuf variables.
+//! 3. **Serialize** protobuf messages and bind them as CEL variables.
+//! 4. **Evaluate** CEL expressions that access message fields.
+//! 5. **Extract** results — scalars directly, or protobuf messages via `as_protobuf_bytes()`.
+//! 6. **Read fields** from Rust with `env.get_protobuf_field()` / `env.has_protobuf_field()`.
+//!
+//! Run with: `cargo run --example protobuf`
+
+use cel_cxx::*;
+
+fn compile_descriptors() -> Vec<u8> {
+    use prost::Message;
+    protox::compile(["tests/fixtures/test.proto"], ["tests/fixtures/"])
+        .expect("failed to compile test.proto")
+        .encode_to_vec()
+}
+
+/// Encode a test.SimpleMessage { name: string, id: int32 } using raw protobuf encoding.
+fn encode_simple_message(name: &str, id: i32) -> Vec<u8> {
+    use prost::encoding::*;
+
+    let mut buf = Vec::new();
+    if !name.is_empty() {
+        encode_key(1, WireType::LengthDelimited, &mut buf);
+        encode_varint(name.len() as u64, &mut buf);
+        buf.extend_from_slice(name.as_bytes());
+    }
+    if id != 0 {
+        encode_key(2, WireType::Varint, &mut buf);
+        encode_varint(id as i64 as u64, &mut buf);
+    }
+    buf
+}
+
+fn main() -> Result<(), Error> {
+    // =========================================================================
+    // 1. Build an environment with protobuf descriptors
+    // =========================================================================
+    let env = Env::builder()
+        .with_file_descriptor_set(&compile_descriptors())
+        .declare_protobuf_variable("msg", "test.SimpleMessage")?
+        .build()?;
+
+    // =========================================================================
+    // 2. Serialize a protobuf message and bind it as a CEL variable
+    // =========================================================================
+    let bytes = encode_simple_message("Alice", 42);
+    println!("Serialized message: {} bytes", bytes.len());
+
+    let activation =
+        Activation::new().bind_protobuf_variable("msg", "test.SimpleMessage", &bytes)?;
+
+    // =========================================================================
+    // 3. Evaluate CEL expressions with field access
+    // =========================================================================
+    println!("\n--- Field access expressions ---");
+    let expressions = [
+        "msg.name",
+        "msg.id",
+        "msg.name == 'Alice'",
+        "msg.id > 0",
+        "msg.name == 'Alice' && msg.id == 42",
+    ];
+
+    for expr in &expressions {
+        let program = env.compile(expr)?;
+        let result = program.evaluate(&activation)?;
+        println!("{expr} => {result}");
+    }
+
+    // =========================================================================
+    // 4. Extract protobuf results with as_protobuf_bytes() and StructValue
+    // =========================================================================
+    println!("\n--- Extracting protobuf results ---");
+    let program = env.compile("msg")?;
+    let result = program.evaluate(&activation)?;
+
+    // Option A: borrow type name and bytes directly
+    let (type_name, result_bytes) = result.as_protobuf_bytes()?;
+    println!("Type: {type_name}, bytes length: {}", result_bytes.len());
+
+    // Option B: extract an owned StructValue via FromValue
+    let sv = StructValue::from_value(&result)?;
+    println!(
+        "StructValue {{ type_name: {:?}, bytes: {} bytes }}",
+        sv.type_name,
+        sv.bytes.len()
+    );
+
+    // =========================================================================
+    // 5. Rust-side field access with get_protobuf_field / has_protobuf_field
+    // =========================================================================
+    println!("\n--- Rust-side field access ---");
+    let name_value = env.get_protobuf_field(&sv, "name")?;
+    let id_value = env.get_protobuf_field(&sv, "id")?;
+    println!("get_protobuf_field(name) => {name_value}");
+    println!("get_protobuf_field(id)   => {id_value}");
+
+    let has_name = env.has_protobuf_field(&sv, "name")?;
+    let has_id = env.has_protobuf_field(&sv, "id")?;
+    println!("has_protobuf_field(name) => {has_name}");
+    println!("has_protobuf_field(id)   => {has_id}");
+
+    // =========================================================================
+    // 6. Message construction in CEL expressions (Type{field: value} syntax)
+    // =========================================================================
+    println!("\n--- Message construction ---");
+    let env2 = Env::builder()
+        .with_file_descriptor_set(&compile_descriptors())
+        .build()?;
+
+    let program = env2.compile("test.SimpleMessage{name: 'Bob', id: 99}")?;
+    let constructed = program.evaluate(&Activation::new())?;
+
+    let (type_name, bytes) = constructed.as_protobuf_bytes()?;
+    println!("Constructed {type_name}: {} bytes", bytes.len());
+
+    // Inline field access on constructed message
+    let program = env2.compile("test.SimpleMessage{name: 'Bob', id: 99}.name")?;
+    let name = program.evaluate(&Activation::new())?;
+    println!("Inline field access: test.SimpleMessage{{...}}.name => {name}");
+
+    Ok(())
+}

--- a/examples/protobuf.rs
+++ b/examples/protobuf.rs
@@ -8,11 +8,11 @@
 //!    [`protox`](https://crates.io/crates/protox) (pure Rust, no external binary needed),
 //!    or offline via `protoc --descriptor_set_out`.
 //!
-//! 2. **Build** an environment with the descriptors and declare protobuf variables.
+//! 2. **Build** an environment with the descriptors and declare struct variables.
 //! 3. **Serialize** protobuf messages and bind them as CEL variables.
 //! 4. **Evaluate** CEL expressions that access message fields.
-//! 5. **Extract** results — scalars directly, or protobuf messages via `as_protobuf_bytes()`.
-//! 6. **Read fields** from Rust with `env.get_protobuf_field()` / `env.has_protobuf_field()`.
+//! 5. **Extract** results — scalars directly, or struct values via `as_struct()`.
+//! 6. **Read fields** from Rust with `env.get_struct_field()` / `env.has_struct_field()`.
 //!
 //! Run with: `cargo run --example protobuf`
 
@@ -48,7 +48,7 @@ fn main() -> Result<(), Error> {
     // =========================================================================
     let env = Env::builder()
         .with_file_descriptor_set(&compile_descriptors())
-        .declare_protobuf_variable("msg", "test.SimpleMessage")?
+        .declare_variable_with_type("msg", ValueType::Struct(StructType::new("test.SimpleMessage")))?
         .build()?;
 
     // =========================================================================
@@ -58,7 +58,7 @@ fn main() -> Result<(), Error> {
     println!("Serialized message: {} bytes", bytes.len());
 
     let activation =
-        Activation::new().bind_protobuf_variable("msg", "test.SimpleMessage", &bytes)?;
+        Activation::new().bind_variable_dynamic("msg", StructValue::from_bytes("test.SimpleMessage", bytes))?;
 
     // =========================================================================
     // 3. Evaluate CEL expressions with field access
@@ -79,37 +79,37 @@ fn main() -> Result<(), Error> {
     }
 
     // =========================================================================
-    // 4. Extract protobuf results with as_protobuf_bytes() and StructValue
+    // 4. Extract struct results with as_struct() and StructValue
     // =========================================================================
-    println!("\n--- Extracting protobuf results ---");
+    println!("\n--- Extracting struct results ---");
     let program = env.compile("msg")?;
     let result = program.evaluate(&activation)?;
 
-    // Option A: borrow type name and bytes directly
-    let (type_name, result_bytes) = result.as_protobuf_bytes()?;
-    println!("Type: {type_name}, bytes length: {}", result_bytes.len());
+    // Option A: borrow via as_struct()
+    let sv_ref = result.as_struct().unwrap();
+    println!("Type: {}, bytes length: {}", sv_ref.type_name(), sv_ref.to_bytes().len());
 
     // Option B: extract an owned StructValue via FromValue
     let sv = StructValue::from_value(&result)?;
     println!(
         "StructValue {{ type_name: {:?}, bytes: {} bytes }}",
-        sv.type_name,
-        sv.bytes.len()
+        sv.type_name(),
+        sv.to_bytes().len()
     );
 
     // =========================================================================
-    // 5. Rust-side field access with get_protobuf_field / has_protobuf_field
+    // 5. Rust-side field access with get_struct_field / has_struct_field
     // =========================================================================
     println!("\n--- Rust-side field access ---");
-    let name_value = env.get_protobuf_field(&sv, "name")?;
-    let id_value = env.get_protobuf_field(&sv, "id")?;
-    println!("get_protobuf_field(name) => {name_value}");
-    println!("get_protobuf_field(id)   => {id_value}");
+    let name_value = env.get_struct_field(&sv, "name")?;
+    let id_value = env.get_struct_field(&sv, "id")?;
+    println!("get_struct_field(name) => {name_value}");
+    println!("get_struct_field(id)   => {id_value}");
 
-    let has_name = env.has_protobuf_field(&sv, "name")?;
-    let has_id = env.has_protobuf_field(&sv, "id")?;
-    println!("has_protobuf_field(name) => {has_name}");
-    println!("has_protobuf_field(id)   => {has_id}");
+    let has_name = env.has_struct_field(&sv, "name")?;
+    let has_id = env.has_struct_field(&sv, "id")?;
+    println!("has_struct_field(name) => {has_name}");
+    println!("has_struct_field(id)   => {has_id}");
 
     // =========================================================================
     // 6. Message construction in CEL expressions (Type{field: value} syntax)
@@ -122,8 +122,8 @@ fn main() -> Result<(), Error> {
     let program = env2.compile("test.SimpleMessage{name: 'Bob', id: 99}")?;
     let constructed = program.evaluate(&Activation::new())?;
 
-    let (type_name, bytes) = constructed.as_protobuf_bytes()?;
-    println!("Constructed {type_name}: {} bytes", bytes.len());
+    let constructed_sv = constructed.as_struct().unwrap();
+    println!("Constructed {}: {} bytes", constructed_sv.type_name(), constructed_sv.to_bytes().len());
 
     // Inline field access on constructed message
     let program = env2.compile("test.SimpleMessage{name: 'Bob', id: 99}.name")?;

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -322,21 +322,22 @@ impl<'f, Fm: FnMarker> Activation<'f, Fm> {
         })
     }
 
-    /// Binds a protobuf message variable from serialized bytes.
+    /// Binds a runtime-typed variable from a [`StructValue`].
     ///
-    /// This method creates a [`StructValue`] from the provided type name and
-    /// serialized bytes, and binds it as a variable. The type name must match
-    /// a type declared via
-    /// [`EnvBuilder::declare_protobuf_variable`](crate::EnvBuilder::declare_protobuf_variable),
+    /// Unlike [`bind_variable`](Self::bind_variable), which infers the CEL type
+    /// from the Rust type via the `TypedValue` trait, this method accepts a
+    /// [`StructValue`] whose type name and serialized bytes are supplied at
+    /// runtime. The type name must match a type declared via
+    /// [`EnvBuilder::declare_variable_with_type`](crate::EnvBuilder::declare_variable_with_type),
     /// and the environment must include the corresponding `FileDescriptorSet`.
+    ///
+    /// For lazily-computed values, see
+    /// [`bind_variable_provider`](Self::bind_variable_provider) instead.
     ///
     /// # Arguments
     ///
-    /// * `name` - The variable name (must match a declared protobuf variable)
-    /// * `type_name` - The fully qualified protobuf message type name (must match the
-    ///   type used in [`EnvBuilder::declare_protobuf_variable`](crate::EnvBuilder::declare_protobuf_variable);
-    ///   a mismatch will cause runtime evaluation errors, not compile-time errors)
-    /// * `bytes` - The serialized protobuf message bytes
+    /// * `name` - The variable name (must match a declared variable)
+    /// * `value` - The [`StructValue`] to bind
     ///
     /// # Examples
     ///
@@ -345,23 +346,21 @@ impl<'f, Fm: FnMarker> Activation<'f, Fm> {
     ///
     /// # let serialized_bytes: Vec<u8> = vec![];
     /// let activation = Activation::new()
-    ///     .bind_protobuf_variable("msg", "my.package.MyMessage", &serialized_bytes)?;
+    ///     .bind_variable_dynamic("msg", StructValue::from_bytes("my.package.MyMessage", serialized_bytes))?;
     /// # Ok::<(), cel_cxx::Error>(())
     /// ```
-    pub fn bind_protobuf_variable<S>(
+    pub fn bind_variable_dynamic<S>(
         mut self,
         name: S,
-        type_name: impl Into<String>,
-        bytes: &[u8],
+        value: StructValue,
     ) -> Result<Self, Error>
     where
         S: Into<String>,
     {
-        let struct_value = StructValue::new(type_name, bytes);
         self.variables.bind_with_value(
             name,
-            crate::ValueType::Struct(crate::types::StructType::new(&struct_value.type_name)),
-            struct_value.into_value(),
+            crate::ValueType::Struct(crate::types::StructType::new(value.type_name())),
+            value.into_value(),
         )?;
         Ok(Activation {
             variables: self.variables,

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -100,7 +100,7 @@
 use crate::function::FunctionBindings;
 use crate::function::{Arguments, NonEmptyArguments, IntoFunction};
 use crate::marker::*;
-use crate::values::{IntoValue, TypedValue};
+use crate::values::{IntoValue, StructValue, TypedValue};
 use crate::variable::VariableBindings;
 use crate::Error;
 use std::marker::PhantomData;
@@ -315,6 +315,54 @@ impl<'f, Fm: FnMarker> Activation<'f, Fm> {
         T: IntoValue + TypedValue,
     {
         self.variables.bind(name, value)?;
+        Ok(Activation {
+            variables: self.variables,
+            functions: self.functions,
+            _fn_marker: PhantomData,
+        })
+    }
+
+    /// Binds a protobuf message variable from serialized bytes.
+    ///
+    /// This method creates a [`StructValue`] from the provided type name and
+    /// serialized bytes, and binds it as a variable. The type name must match
+    /// a type declared via
+    /// [`EnvBuilder::declare_protobuf_variable`](crate::EnvBuilder::declare_protobuf_variable),
+    /// and the environment must include the corresponding `FileDescriptorSet`.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The variable name (must match a declared protobuf variable)
+    /// * `type_name` - The fully qualified protobuf message type name (must match the
+    ///   type used in [`EnvBuilder::declare_protobuf_variable`](crate::EnvBuilder::declare_protobuf_variable);
+    ///   a mismatch will cause runtime evaluation errors, not compile-time errors)
+    /// * `bytes` - The serialized protobuf message bytes
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use cel_cxx::*;
+    ///
+    /// # let serialized_bytes: Vec<u8> = vec![];
+    /// let activation = Activation::new()
+    ///     .bind_protobuf_variable("msg", "my.package.MyMessage", &serialized_bytes)?;
+    /// # Ok::<(), cel_cxx::Error>(())
+    /// ```
+    pub fn bind_protobuf_variable<S>(
+        mut self,
+        name: S,
+        type_name: impl Into<String>,
+        bytes: &[u8],
+    ) -> Result<Self, Error>
+    where
+        S: Into<String>,
+    {
+        let struct_value = StructValue::new(type_name, bytes);
+        self.variables.bind_with_value(
+            name,
+            crate::ValueType::Struct(crate::types::StructType::new(&struct_value.type_name)),
+            struct_value.into_value(),
+        )?;
         Ok(Activation {
             variables: self.variables,
             functions: self.functions,

--- a/src/env/inner.rs
+++ b/src/env/inner.rs
@@ -25,6 +25,7 @@ pub struct EnvInner<'f> {
 #[derive(Debug)]
 pub struct EnvInnerOptions {
     pub container: String,
+    pub file_descriptor_set: Option<Vec<u8>>,
     pub enable_standard: bool,
     pub enable_optional: bool,
     pub enable_ext_bindings: bool,
@@ -44,6 +45,7 @@ impl Default for EnvInnerOptions {
     fn default() -> Self {
         Self {
             container: "".to_string(),
+            file_descriptor_set: None,
             enable_standard: true,
             enable_optional: false,
             enable_ext_bindings: false,
@@ -89,11 +91,16 @@ impl<'f> EnvInner<'f> {
             macros: macros.clone(),
             function_registry: function_registry.clone(),
             variable_registry: variable_registry.clone(),
-            ffi_ctx: ffi::Ctx::new_generated(),
+            ffi_ctx: match &env_options.file_descriptor_set {
+                Some(fds) => ffi::Ctx::new_dynamic(fds).map_err(|e| {
+                    ffi::Status::invalid_argument(e)
+                })?,
+                None => ffi::Ctx::new_generated(),
+            },
             ffi_compiler_builder: |ffi_ctx: &ffi::Ctx| {
                 let options = ffi::CompilerOptions::new();
                 let mut builder =
-                    ffi::CompilerBuilder::new(ffi::DescriptorPool::generated(), &options)?;
+                    ffi::CompilerBuilder::new(ffi_ctx.shared_descriptor_pool().clone(), &options)?;
                 
                 if !env_options.container.is_empty() {
                     builder
@@ -256,7 +263,11 @@ impl<'f> EnvInner<'f> {
                         .push_str(&env_options.container);
                 }
 
-                if env_options.enable_optional {
+                // Qualified type identifiers are required for:
+                // - Optional values: enables optional.of(), optional.none(), etc.
+                // - Custom descriptor pools: enables fully-qualified enum constant
+                //   resolution (e.g. package.EnumType.ENUM_VALUE) via the runtime Resolver.
+                if env_options.enable_optional || env_options.file_descriptor_set.is_some() {
                     *options.pin_mut().enable_qualified_type_identifiers_mut() = true;
                 }
 
@@ -268,6 +279,19 @@ impl<'f> EnvInner<'f> {
                 }
                 if env_options.enable_optional {
                     builder.pin_mut().enable_optional(&options)?;
+                }
+
+                // Register enum constants from the custom descriptor pool so that
+                // named enum references (e.g. test.Status.STATUS_ACTIVE) resolve
+                // at plan time.
+                if let Some(fds) = &env_options.file_descriptor_set {
+                    builder
+                        .pin_mut()
+                        .type_registry()
+                        .register_enums_from_file_descriptor_set(
+                            ffi_ctx.descriptor_pool(),
+                            fds,
+                        )?;
                 }
 
                 if env_options.enable_ext_comprehensions {

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -119,21 +119,21 @@ impl<'f, Fm: FnMarker, Rm: RuntimeMarker> Env<'f, Fm, Rm> {
         self.inner.clone().compile::<Fm, Rm, _>(source)
     }
 
-    /// Reads a field from a protobuf `StructValue` by name, returning it as a Rust `Value`.
+    /// Reads a field from a [`StructValue`](crate::StructValue) by name, returning it as a Rust [`Value`](crate::Value).
     ///
-    /// This allows programmatic field access on protobuf messages returned from
+    /// This allows programmatic field access on struct values returned from
     /// CEL evaluation, without needing to compile and evaluate another CEL expression
-    /// or deserialize with prost.
+    /// or deserialize the message externally.
     ///
     /// # Arguments
     ///
-    /// * `struct_value` - The protobuf struct value to read from
+    /// * `struct_value` - The struct value to read from
     /// * `field_name` - The field name to access
     ///
     /// # Errors
     ///
     /// Returns an error if the field does not exist or the message cannot be deserialized.
-    pub fn get_protobuf_field(
+    pub fn get_struct_field(
         &self,
         struct_value: &crate::StructValue,
         field_name: &str,
@@ -143,8 +143,8 @@ impl<'f, Fm: FnMarker, Rm: RuntimeMarker> Env<'f, Fm, Rm> {
             ctx.arena(),
             ctx.descriptor_pool(),
             ctx.message_factory(),
-            &struct_value.type_name,
-            &struct_value.bytes,
+            struct_value.type_name(),
+            struct_value.to_bytes(),
         )
         .map_err(|e| Error::from(&e))?;
         let ffi_value = msg
@@ -163,20 +163,20 @@ impl<'f, Fm: FnMarker, Rm: RuntimeMarker> Env<'f, Fm, Rm> {
         )
     }
 
-    /// Checks whether a field is set on a protobuf `StructValue`.
+    /// Checks whether a field is set on a [`StructValue`](crate::StructValue).
     ///
-    /// For proto3 messages, this checks whether the field has a non-default value.
-    /// For proto3 optional fields, this checks field presence.
+    /// The exact semantics are determined by cel-cpp based on the field's
+    /// presence rules in the proto schema (e.g. implicit vs. explicit field presence).
     ///
     /// # Arguments
     ///
-    /// * `struct_value` - The protobuf struct value to check
+    /// * `struct_value` - The struct value to check
     /// * `field_name` - The field name to check
     ///
     /// # Errors
     ///
     /// Returns an error if the message cannot be deserialized.
-    pub fn has_protobuf_field(
+    pub fn has_struct_field(
         &self,
         struct_value: &crate::StructValue,
         field_name: &str,
@@ -186,8 +186,8 @@ impl<'f, Fm: FnMarker, Rm: RuntimeMarker> Env<'f, Fm, Rm> {
             ctx.arena(),
             ctx.descriptor_pool(),
             ctx.message_factory(),
-            &struct_value.type_name,
-            &struct_value.bytes,
+            struct_value.type_name(),
+            struct_value.to_bytes(),
         )
         .map_err(|e| Error::from(&e))?;
         Ok(msg.has_field_by_name(field_name))
@@ -307,8 +307,9 @@ impl<'f, Fm: FnMarker, Rm: RuntimeMarker> EnvBuilder<'f, Fm, Rm> {
     /// ```rust,no_run
     /// use cel_cxx::*;
     ///
+    /// # let descriptor_bytes: &[u8] = &[];
     /// let env = Env::builder()
-    ///     .with_file_descriptor_set(include_bytes!("descriptors.bin"))
+    ///     .with_file_descriptor_set(descriptor_bytes)
     ///     .build()?;
     /// # Ok::<(), cel_cxx::Error>(())
     /// ```
@@ -1764,40 +1765,42 @@ impl<'f, Fm: FnMarker, Rm: RuntimeMarker> EnvBuilder<'f, Fm, Rm> {
         })
     }
 
-    /// Declares a protobuf message variable with the given fully-qualified type name.
+    /// Declares a variable with an explicit [`ValueType`].
     ///
-    /// This declares that a variable of the given name will hold a protobuf message
-    /// of the specified type. The environment must have been configured with
-    /// [`with_file_descriptor_set`](Self::with_file_descriptor_set) containing the
-    /// type's descriptor.
+    /// This is useful for declaring variables whose types are not statically known
+    /// at compile time, such as struct types loaded from a `FileDescriptorSet`.
+    /// The environment must have been configured with
+    /// [`with_file_descriptor_set`](Self::with_file_descriptor_set) when using
+    /// struct types.
     ///
     /// At evaluation time, bind the variable using
-    /// [`Activation::bind_protobuf_variable`](crate::Activation::bind_protobuf_variable).
+    /// [`Activation::bind_variable_dynamic`](crate::Activation::bind_variable_dynamic).
     ///
     /// # Arguments
     ///
     /// * `name` - The variable name
-    /// * `type_name` - The fully qualified protobuf message type name (e.g. `"my.package.MyMessage"`)
+    /// * `value_type` - The [`ValueType`] of the variable
     ///
     /// # Examples
     ///
     /// ```rust,no_run
     /// use cel_cxx::*;
     ///
+    /// # let descriptor_bytes: &[u8] = &[];
     /// let env = Env::builder()
-    ///     .with_file_descriptor_set(include_bytes!("descriptors.bin"))
-    ///     .declare_protobuf_variable("msg", "my.package.MyMessage")?
+    ///     .with_file_descriptor_set(descriptor_bytes)
+    ///     .declare_variable_with_type("msg", ValueType::Struct(StructType::new("my.package.MyMessage")))?
     ///     .build()?;
     /// # Ok::<(), cel_cxx::Error>(())
     /// ```
-    pub fn declare_protobuf_variable(
+    pub fn declare_variable_with_type(
         mut self,
         name: impl Into<String>,
-        type_name: impl Into<String>,
+        value_type: crate::ValueType,
     ) -> Result<Self, Error> {
         self.variable_registry.declare_with_type(
             name,
-            crate::ValueType::Struct(crate::types::StructType::new(type_name)),
+            value_type,
         )?;
         Ok(EnvBuilder {
             macros: self.macros,

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -118,6 +118,80 @@ impl<'f, Fm: FnMarker, Rm: RuntimeMarker> Env<'f, Fm, Rm> {
     pub fn compile<S: AsRef<[u8]>>(&self, source: S) -> Result<Program<'f, Fm, Rm>, Error> {
         self.inner.clone().compile::<Fm, Rm, _>(source)
     }
+
+    /// Reads a field from a protobuf `StructValue` by name, returning it as a Rust `Value`.
+    ///
+    /// This allows programmatic field access on protobuf messages returned from
+    /// CEL evaluation, without needing to compile and evaluate another CEL expression
+    /// or deserialize with prost.
+    ///
+    /// # Arguments
+    ///
+    /// * `struct_value` - The protobuf struct value to read from
+    /// * `field_name` - The field name to access
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the field does not exist or the message cannot be deserialized.
+    pub fn get_protobuf_field(
+        &self,
+        struct_value: &crate::StructValue,
+        field_name: &str,
+    ) -> Result<crate::Value, Error> {
+        let ctx = self.inner.ctx().clone_with_new_arena();
+        let msg = crate::ffi::MessageValue::from_bytes(
+            ctx.arena(),
+            ctx.descriptor_pool(),
+            ctx.message_factory(),
+            &struct_value.type_name,
+            &struct_value.bytes,
+        )
+        .map_err(|e| Error::from(&e))?;
+        let ffi_value = msg
+            .get_field_by_name(
+                ctx.descriptor_pool(),
+                ctx.message_factory(),
+                ctx.arena(),
+                field_name,
+            )
+            .map_err(|e| Error::from(&e))?;
+        crate::ffi::value_to_rust(
+            &ffi_value,
+            ctx.arena(),
+            ctx.descriptor_pool(),
+            ctx.message_factory(),
+        )
+    }
+
+    /// Checks whether a field is set on a protobuf `StructValue`.
+    ///
+    /// For proto3 messages, this checks whether the field has a non-default value.
+    /// For proto3 optional fields, this checks field presence.
+    ///
+    /// # Arguments
+    ///
+    /// * `struct_value` - The protobuf struct value to check
+    /// * `field_name` - The field name to check
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the message cannot be deserialized.
+    pub fn has_protobuf_field(
+        &self,
+        struct_value: &crate::StructValue,
+        field_name: &str,
+    ) -> Result<bool, Error> {
+        let ctx = self.inner.ctx().clone_with_new_arena();
+        let msg = crate::ffi::MessageValue::from_bytes(
+            ctx.arena(),
+            ctx.descriptor_pool(),
+            ctx.message_factory(),
+            &struct_value.type_name,
+            &struct_value.bytes,
+        )
+        .map_err(|e| Error::from(&e))?;
+        Ok(msg.has_field_by_name(field_name))
+    }
 }
 
 /// Builder for creating CEL environments.
@@ -211,6 +285,35 @@ impl<'f, Fm: FnMarker, Rm: RuntimeMarker> EnvBuilder<'f, Fm, Rm> {
     /// ```
     pub fn with_container(mut self, container: impl Into<String>) -> Self {
         self.options.container = container.into();
+        self
+    }
+
+    /// Sets a custom `FileDescriptorSet` for the environment's protobuf descriptor pool.
+    ///
+    /// **Default**: `None` (uses the generated/built-in descriptor pool)
+    ///
+    /// When set, the environment will use a custom descriptor pool built from the provided
+    /// serialized `FileDescriptorSet` bytes. This allows CEL expressions to reference
+    /// user-defined protobuf message types. Well-known types (Duration, Timestamp, etc.)
+    /// remain available as the generated pool is used as an underlay.
+    ///
+    /// # Arguments
+    ///
+    /// * `file_descriptor_set` - Serialized `FileDescriptorSet` proto bytes, produced by
+    ///   [`protox::compile`](https://docs.rs/protox) or `protoc --descriptor_set_out`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use cel_cxx::*;
+    ///
+    /// let env = Env::builder()
+    ///     .with_file_descriptor_set(include_bytes!("descriptors.bin"))
+    ///     .build()?;
+    /// # Ok::<(), cel_cxx::Error>(())
+    /// ```
+    pub fn with_file_descriptor_set(mut self, file_descriptor_set: &[u8]) -> Self {
+        self.options.file_descriptor_set = Some(file_descriptor_set.to_vec());
         self
     }
 
@@ -1651,6 +1754,51 @@ impl<'f, Fm: FnMarker, Rm: RuntimeMarker> EnvBuilder<'f, Fm, Rm> {
         T: TypedValue,
     {
         self.variable_registry.declare::<T>(name)?;
+        Ok(EnvBuilder {
+            macros: self.macros,
+            function_registry: self.function_registry,
+            variable_registry: self.variable_registry,
+            options: self.options,
+            _fn_marker: std::marker::PhantomData,
+            _rt_marker: std::marker::PhantomData,
+        })
+    }
+
+    /// Declares a protobuf message variable with the given fully-qualified type name.
+    ///
+    /// This declares that a variable of the given name will hold a protobuf message
+    /// of the specified type. The environment must have been configured with
+    /// [`with_file_descriptor_set`](Self::with_file_descriptor_set) containing the
+    /// type's descriptor.
+    ///
+    /// At evaluation time, bind the variable using
+    /// [`Activation::bind_protobuf_variable`](crate::Activation::bind_protobuf_variable).
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The variable name
+    /// * `type_name` - The fully qualified protobuf message type name (e.g. `"my.package.MyMessage"`)
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use cel_cxx::*;
+    ///
+    /// let env = Env::builder()
+    ///     .with_file_descriptor_set(include_bytes!("descriptors.bin"))
+    ///     .declare_protobuf_variable("msg", "my.package.MyMessage")?
+    ///     .build()?;
+    /// # Ok::<(), cel_cxx::Error>(())
+    /// ```
+    pub fn declare_protobuf_variable(
+        mut self,
+        name: impl Into<String>,
+        type_name: impl Into<String>,
+    ) -> Result<Self, Error> {
+        self.variable_registry.declare_with_type(
+            name,
+            crate::ValueType::Struct(crate::types::StructType::new(type_name)),
+        )?;
         Ok(EnvBuilder {
             macros: self.macros,
             function_registry: self.function_registry,

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -388,19 +388,19 @@ impl<'f, Fm: FnMarker, Rm: RuntimeMarker> EnvBuilder<'f, Fm, Rm> {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// use cel_cxx::*;
-    /// 
+    ///
     /// let env = Env::builder()
     ///     .with_optional(true)
     ///     .build()?;
-    /// 
+    ///
     /// // Optional field selection
     /// let program = env.compile("msg.?field.orValue('default')")?;
-    /// 
+    ///
     /// // Optional map construction
     /// let program2 = env.compile("{'name': 'bob', ?'age': optional.of(25)}")?;
-    /// 
+    ///
     /// // Optional indexing
     /// let program3 = env.compile("list[?5].hasValue()")?;
     /// # Ok::<(), cel_cxx::Error>(())
@@ -658,7 +658,7 @@ impl<'f, Fm: FnMarker, Rm: RuntimeMarker> EnvBuilder<'f, Fm, Rm> {
     /// // Decode Base64 to bytes
     /// let program2 = env.compile("base64.decode('aGVsbG8=')")?;
     /// let result2 = program2.evaluate(&Activation::new())?;
-    /// assert_eq!(result2, Value::Bytes(b"hello".to_vec()));
+    /// assert_eq!(result2, Value::Bytes(b"hello".to_vec().into()));
     /// # Ok::<(), cel_cxx::Error>(())
     /// ```
     pub fn with_ext_encoders(mut self, enable: bool) -> Self {
@@ -1137,17 +1137,17 @@ impl<'f, Fm: FnMarker, Rm: RuntimeMarker> EnvBuilder<'f, Fm, Rm> {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// use cel_cxx::*;
-    /// 
+    ///
     /// let env = Env::builder()
     ///     .with_ext_select_optimization(true)
     ///     .build()?;
-    /// 
+    ///
     /// // Field access operations may be optimized
     /// let program = env.compile("user.profile.settings.theme")?;
-    /// 
-    /// // Map access patterns may be optimized  
+    ///
+    /// // Map access patterns may be optimized
     /// let program2 = env.compile("config['database']['host']")?;
     /// # Ok::<(), cel_cxx::Error>(())
     /// ```
@@ -1188,7 +1188,7 @@ impl<'f, Fm: FnMarker, Rm: RuntimeMarker> EnvBuilder<'f, Fm, Rm> {
     /// ## Registering a global macro
     ///
     /// ```rust,no_run
-    /// # use cel_cxx::{EnvBuilder, Error};
+    /// # use cel_cxx::{Env, EnvBuilder, Error};
     /// # use cel_cxx::macros::Macro;
     /// # fn example() -> Result<(), Error> {
     /// // Create a macro that expands not_zero(x) to x != 0
@@ -1197,7 +1197,7 @@ impl<'f, Fm: FnMarker, Rm: RuntimeMarker> EnvBuilder<'f, Fm, Rm> {
     ///     Some(factory.new_call("_!=_", &[arg, factory.new_const(0)]))
     /// })?;
     ///
-    /// let env = EnvBuilder::new()
+    /// let env: Env = EnvBuilder::new()
     ///     .register_macro(not_zero)?
     ///     .build()?;
     ///
@@ -1210,21 +1210,22 @@ impl<'f, Fm: FnMarker, Rm: RuntimeMarker> EnvBuilder<'f, Fm, Rm> {
     /// ## Registering a receiver macro
     ///
     /// ```rust,no_run
-    /// # use cel_cxx::{EnvBuilder, Error};
+    /// # use cel_cxx::{Env, EnvBuilder, Error};
     /// # use cel_cxx::macros::Macro;
     /// # fn example() -> Result<(), Error> {
     /// // Create a macro for optional chaining: target.get_or(default)
     /// let get_or = Macro::new_receiver("get_or", 1, |factory, target, mut args| {
     ///     let default_val = args.pop()?;
     ///     // Expand to: target != null ? target : default_val
+    ///     let target_copy = factory.copy_expr(&target);
     ///     let null_check = factory.new_call("_!=_", &[
-    ///         target.clone(),
+    ///         target_copy,
     ///         factory.new_const(())
     ///     ]);
     ///     Some(factory.new_call("_?_:_", &[null_check, target, default_val]))
     /// })?;
     ///
-    /// let env = EnvBuilder::new()
+    /// let env: Env = EnvBuilder::new()
     ///     .register_macro(get_or)?
     ///     .build()?;
     ///
@@ -1237,7 +1238,7 @@ impl<'f, Fm: FnMarker, Rm: RuntimeMarker> EnvBuilder<'f, Fm, Rm> {
     /// ## Multiple macros
     ///
     /// ```rust,no_run
-    /// # use cel_cxx::{EnvBuilder, Error};
+    /// # use cel_cxx::{Env, EnvBuilder, Error};
     /// # use cel_cxx::macros::Macro;
     /// # fn example() -> Result<(), Error> {
     /// let macro1 = Macro::new_global("custom_op", 2, |factory, args| {
@@ -1250,7 +1251,7 @@ impl<'f, Fm: FnMarker, Rm: RuntimeMarker> EnvBuilder<'f, Fm, Rm> {
     ///     None
     /// })?;
     ///
-    /// let env = EnvBuilder::new()
+    /// let env: Env = EnvBuilder::new()
     ///     .register_macro(macro1)?
     ///     .register_macro(macro2)?
     ///     .build()?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -715,6 +715,7 @@ impl From<&Error> for crate::ffi::Status {
     fn from(value: &Error) -> Self {
         use crate::ffi::Status;
         match value.code() {
+            // OK status carries no message by convention; the message is intentionally dropped.
             Code::Ok => Status::ok(),
             Code::Cancelled => Status::cancelled(value.message()),
             Code::Unknown => Status::unknown(value.message()),

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -8,11 +8,15 @@ pub(crate) use activation::*;
 pub(crate) use types::*;
 pub(crate) use values::*;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Ctx {
     arena: cxx::SharedPtr<Arena>,
     descriptor_pool: cxx::SharedPtr<DescriptorPool>,
     message_factory: cxx::SharedPtr<MessageFactory>,
+    /// Whether this context uses a dynamic descriptor pool/message factory.
+    /// DynamicMessageFactory is not thread-safe, so clone_with_new_arena must
+    /// create a fresh instance for each evaluation context.
+    is_dynamic: bool,
 }
 
 impl Ctx {
@@ -21,23 +25,32 @@ impl Ctx {
             arena: Arena::new(),
             descriptor_pool: DescriptorPool::generated(),
             message_factory: MessageFactory::generated(),
+            is_dynamic: false,
         }
     }
 
-    #[allow(unused)]
-    pub fn new_dynamic(file_descriptor_set: &[u8]) -> Self {
-        Self {
+    pub fn new_dynamic(file_descriptor_set: &[u8]) -> Result<Self, &'static str> {
+        Ok(Self {
             arena: Arena::new(),
-            descriptor_pool: DescriptorPool::new(file_descriptor_set),
+            descriptor_pool: DescriptorPool::new(file_descriptor_set)?,
             message_factory: MessageFactory::new(),
-        }
+            is_dynamic: true,
+        })
     }
 
     pub fn clone_with_new_arena(&self) -> Self {
         Self {
             arena: Arena::new(),
             descriptor_pool: self.descriptor_pool.clone(),
-            message_factory: self.message_factory.clone(),
+            // DynamicMessageFactory is not thread-safe for concurrent use.
+            // Create a fresh instance for each evaluation context to avoid
+            // data races when multiple threads evaluate concurrently.
+            message_factory: if self.is_dynamic {
+                MessageFactory::new()
+            } else {
+                self.message_factory.clone()
+            },
+            is_dynamic: self.is_dynamic,
         }
     }
 
@@ -69,5 +82,15 @@ impl Ctx {
         self.message_factory
             .as_ref()
             .expect("message factory is not initialized")
+    }
+}
+
+impl Clone for Ctx {
+    /// Clones the context with a new arena and (if dynamic) a fresh MessageFactory.
+    ///
+    /// This ensures `DynamicMessageFactory` is never shared across threads,
+    /// which would cause data races since it is not thread-safe.
+    fn clone(&self) -> Self {
+        self.clone_with_new_arena()
     }
 }

--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -13,8 +13,9 @@ pub(crate) fn type_from_rust<'a>(
         rust::ValueType::Double => Type::new_double(),
         rust::ValueType::String => Type::new_string(),
         rust::ValueType::Bytes => Type::new_bytes(),
-        rust::ValueType::Struct(_struct_type) => {
-            todo!()
+        rust::ValueType::Struct(struct_type) => {
+            let message_type = message_type_from_rust(&struct_type.name, descriptor_pool);
+            Type::new_message(&message_type)
         }
         rust::ValueType::Duration => Type::new_duration(),
         rust::ValueType::Timestamp => Type::new_timestamp(),
@@ -111,7 +112,6 @@ fn type_type_from_rust<'a>(
     }
 }
 
-#[allow(dead_code)]
 fn message_type_from_rust<'a>(
     message: &str,
     descriptor_pool: &'a DescriptorPool,
@@ -241,7 +241,10 @@ fn mapkey_type_to_rust<'a>(type_: &Type<'a>) -> rust::MapKeyType {
             let type_param_type = type_.get_type_param();
             rust::MapKeyType::TypeParam(type_param_type_to_rust(&type_param_type))
         }
-        _ => rust::MapKeyType::Dyn,
+        other => {
+            debug_assert!(false, "unexpected map key type kind: {:?}", other);
+            rust::MapKeyType::Dyn
+        }
     }
 }
 

--- a/src/ffi/values.rs
+++ b/src/ffi/values.rs
@@ -32,8 +32,23 @@ pub(crate) fn value_from_rust<'a>(
             let bytes_value = BytesValue::new(arena, b);
             Value::new_bytes(&bytes_value)
         }
-        rust::Value::Struct(_s) => {
-            todo!()
+        rust::Value::Struct(s) => {
+            // Deserialization errors become CEL error values rather than Rust errors.
+            // This follows CEL semantics: expressions can observe errors as values
+            // (e.g., via `try()` or short-circuit evaluation) rather than aborting.
+            match MessageValue::from_bytes(
+                arena,
+                descriptor_pool,
+                message_factory,
+                &s.type_name,
+                &s.bytes,
+            ) {
+                Ok(message_value) => Value::new_message(&message_value),
+                Err(status) => {
+                    let error_value = ErrorValue::new(status);
+                    Value::new_error(&error_value)
+                }
+            }
         }
         rust::Value::Duration(d) => {
             let duration = (*d).into();
@@ -70,7 +85,10 @@ pub(crate) fn value_from_rust<'a>(
             Value::new_map(&map_value)
         }
         rust::Value::Unknown(..) => {
-            todo!()
+            let error_value = ErrorValue::new(
+                super::Status::internal("cannot convert Unknown value to FFI"),
+            );
+            Value::new_error(&error_value)
         }
         rust::Value::Type(t) => {
             let type_ = super::type_from_rust(t, arena, descriptor_pool);
@@ -127,9 +145,15 @@ pub(crate) fn value_to_rust<'a>(
             Ok(rust::Value::Bytes(bytes_value.native_value().into()))
         }
         ValueKind::Struct => {
-            todo!()
-            //let struct_value = value.get_message();
-            //rust::Value::Message(struct_value.native_value())
+            let message_value = value.get_message();
+            let type_name = message_value.type_name();
+            let bytes = message_value
+                .to_bytes()
+                .map_err(|e| rust::Error::from(&e))?;
+            Ok(rust::Value::Struct(rust::StructValue {
+                type_name,
+                bytes,
+            }))
         }
         ValueKind::Duration => {
             let duration_value = value.get_duration();
@@ -186,7 +210,7 @@ pub(crate) fn value_to_rust<'a>(
             Ok(rust::Value::Map(result))
         }
         ValueKind::Unknown => {
-            todo!()
+            Err(rust::Error::internal("Unknown values are not supported"))
         }
         ValueKind::Type => {
             let type_value = value.get_type();

--- a/src/ffi/values.rs
+++ b/src/ffi/values.rs
@@ -40,8 +40,8 @@ pub(crate) fn value_from_rust<'a>(
                 arena,
                 descriptor_pool,
                 message_factory,
-                &s.type_name,
-                &s.bytes,
+                s.type_name(),
+                s.to_bytes(),
             ) {
                 Ok(message_value) => Value::new_message(&message_value),
                 Err(status) => {
@@ -150,10 +150,10 @@ pub(crate) fn value_to_rust<'a>(
             let bytes = message_value
                 .to_bytes()
                 .map_err(|e| rust::Error::from(&e))?;
-            Ok(rust::Value::Struct(rust::StructValue {
+            Ok(rust::Value::Struct(rust::StructValue::from_bytes(
                 type_name,
                 bytes,
-            }))
+            )))
         }
         ValueKind::Duration => {
             let duration_value = value.get_duration();

--- a/src/macros/expander.rs
+++ b/src/macros/expander.rs
@@ -21,16 +21,17 @@ use super::{MacroExprFactory, Expr};
 ///
 /// ```rust,no_run
 /// # use cel_cxx::macros::{GlobalMacroExpander, MacroExprFactory, Expr};
+/// # use cel_cxx::Constant;
 /// // Simple constant-folding macro
 /// fn optimize_add(factory: &mut MacroExprFactory, args: Vec<Expr>) -> Option<Expr> {
 ///     if args.len() != 2 {
 ///         return None;
 ///     }
-///     
+///
 ///     // If both args are constant integers, fold them
-///     let left = args[0].kind()?.as_constant()?.as_int()?;
-///     let right = args[1].kind()?.as_constant()?.as_int()?;
-///     
+///     let left = match args[0].kind()?.as_constant()? { Constant::Int(n) => *n, _ => return None };
+///     let right = match args[1].kind()?.as_constant()? { Constant::Int(n) => *n, _ => return None };
+///
 ///     Some(factory.new_const(left + right))
 /// }
 /// ```
@@ -84,8 +85,9 @@ impl<'f, F> GlobalMacroExpander for F where F
 ///     let default_value = args.pop()?;
 ///     
 ///     // Expand to: target != null ? target : default_value
+///     let target_copy = factory.copy_expr(&target);
 ///     Some(factory.new_call("_?_:_", &[
-///         factory.new_call("_!=_", &[target.clone(), factory.new_const(())]),
+///         factory.new_call("_!=_", &[target_copy, factory.new_const(())]),
 ///         target,
 ///         default_value,
 ///     ]))

--- a/src/macros/expr.rs
+++ b/src/macros/expr.rs
@@ -53,13 +53,13 @@ impl std::ops::Deref for Expr {
     type Target = ExprKind;
 
     fn deref(&self) -> &Self::Target {
-        self.kind.as_ref().unwrap()
+        self.kind.as_ref().expect("Expr has no kind set")
     }
 }
 
 impl std::ops::DerefMut for Expr {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.kind.as_mut().unwrap()
+        self.kind.as_mut().expect("Expr has no kind set")
     }
 }
 

--- a/src/macros/factory.rs
+++ b/src/macros/factory.rs
@@ -34,7 +34,8 @@ use std::pin::Pin;
 ///     let const_expr = factory.new_const(42);
 ///     
 ///     // Create a function call expression
-///     let call_expr = factory.new_call("size", &[args[0].clone()]);
+///     let arg_copy = factory.copy_expr(&args[0]);
+///     let call_expr = factory.new_call("size", &[arg_copy]);
 ///     
 ///     // Create a binary operation
 ///     let result = factory.new_call("_>_", &[call_expr, const_expr]);

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -29,13 +29,14 @@
 //!
 //! ```rust,no_run
 //! use cel_cxx::macros::{Macro, MacroExprFactory, Expr};
+//! use cel_cxx::Constant;
 //!
 //! // Macro that creates a constant expression with doubled value
 //! let double_macro = Macro::new_global("double", 1, |factory, args| {
 //!     if let Some(expr) = args.first() {
 //!         if let Some(val) = expr.kind().and_then(|k| k.as_constant()) {
-//!             if let Some(int_val) = val.as_int() {
-//!                 return Some(factory.new_const(int_val * 2));
+//!             if let Constant::Int(int_val) = val {
+//!                 return Some(factory.new_const(*int_val * 2));
 //!             }
 //!         }
 //!     }
@@ -50,7 +51,8 @@
 //! // Macro for optional element access: list.maybe_get(index)
 //! let maybe_get_macro = Macro::new_receiver("maybe_get", 1, |factory, target, args| {
 //!     // Implementation would handle optional list indexing
-//!     Some(factory.new_call("_?.[]", &[target, args[0].clone()]))
+//!     let arg_copy = factory.copy_expr(&args[0]);
+//!     Some(factory.new_call("_?.[]", &[target, arg_copy]))
 //! });
 //! ```
 
@@ -229,7 +231,9 @@ impl Macro {
     ///     }
     ///     // Implementation would build comparison chain
     ///     Some(args.into_iter().reduce(|acc, arg| {
-    ///         factory.new_call("_>_?_:_", &[acc, arg.clone(), acc.clone(), arg])
+    ///         let arg_copy = factory.copy_expr(&arg);
+    ///         let acc_copy = factory.copy_expr(&acc);
+    ///         factory.new_call("_>_?_:_", &[acc, arg_copy, acc_copy, arg])
     ///     })?)
     /// })?;
     /// # Ok(())

--- a/src/program/inner.rs
+++ b/src/program/inner.rs
@@ -136,6 +136,9 @@ impl<'f> ProgramInner<'f> {
                     &ffi_activation,
                 )
                 .map_err(|ffi_status| Error::from(ffi_status))?;
+            if ffi_value.is_null() {
+                return Err(Error::unknown("evaluation returned null"));
+            }
             let value = ffi::value_to_rust(
                 &ffi_value,
                 eval_ctx.arena(),

--- a/src/values/display.rs
+++ b/src/values/display.rs
@@ -11,7 +11,7 @@ impl std::fmt::Display for Value {
             Value::Double(d) => write!(f, "{d}"),
             Value::String(s) => write!(f, "{s:?}"),
             Value::Bytes(b) => write!(f, "{}", display_bytes(b)),
-            Value::Struct(_s) => write!(f, ""),
+            Value::Struct(s) => write!(f, "{}{{...}}", s.type_name),
             Value::Duration(d) => write!(f, "{d}"),
             Value::Timestamp(t) => write!(f, "{t}"),
             Value::List(l) => write!(f, "[{}]", l.iter().format(", ")),

--- a/src/values/display.rs
+++ b/src/values/display.rs
@@ -11,7 +11,7 @@ impl std::fmt::Display for Value {
             Value::Double(d) => write!(f, "{d}"),
             Value::String(s) => write!(f, "{s:?}"),
             Value::Bytes(b) => write!(f, "{}", display_bytes(b)),
-            Value::Struct(s) => write!(f, "{}{{...}}", s.type_name),
+            Value::Struct(s) => write!(f, "{}{{...}}", s.type_name()),
             Value::Duration(d) => write!(f, "{d}"),
             Value::Timestamp(t) => write!(f, "{t}"),
             Value::List(l) => write!(f, "[{}]", l.iter().format(", ")),

--- a/src/values/impls/struct.rs
+++ b/src/values/impls/struct.rs
@@ -1,1 +1,38 @@
-// TODO: Implement structs
+use crate::{types::*, values::*};
+
+impl IntoValue for StructValue {
+    fn into_value(self) -> Value {
+        Value::Struct(self)
+    }
+}
+
+impl TypedValue for StructValue {
+    /// Returns `Dyn` because `TypedValue` is a static trait method with no access
+    /// to the instance's `type_name`. The actual message type is resolved at the
+    /// FFI layer during evaluation via the DescriptorPool.
+    fn value_type() -> ValueType {
+        ValueType::Dyn
+    }
+}
+
+impl FromValue for StructValue {
+    type Output<'a> = StructValue;
+
+    fn from_value<'a>(value: &'a Value) -> Result<Self::Output<'a>, FromValueError> {
+        match value {
+            Value::Struct(s) => Ok(s.clone()),
+            _ => Err(FromValueError::new(value.clone(), "struct")),
+        }
+    }
+}
+
+impl FromValue for &StructValue {
+    type Output<'a> = &'a StructValue;
+
+    fn from_value<'a>(value: &'a Value) -> Result<Self::Output<'a>, FromValueError> {
+        match value {
+            Value::Struct(s) => Ok(s),
+            _ => Err(FromValueError::new(value.clone(), "struct")),
+        }
+    }
+}

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -204,6 +204,29 @@ pub type ListValue = Vec<Value>;
 /// CEL map value type.
 pub type MapValue = HashMap<MapKey, Value>;
 
+/// CEL struct value representing a Protocol Buffers message.
+///
+/// The message is stored as its fully-qualified type name plus serialized bytes.
+/// Deserialization into C++ `MessageValue` happens at the FFI boundary when the
+/// value is passed to cel-cpp for evaluation.
+#[derive(Clone, Debug, PartialEq)]
+pub struct StructValue {
+    /// The fully qualified protobuf message type name (e.g. `"my.package.MyMessage"`).
+    pub type_name: String,
+    /// The serialized protobuf bytes of the message.
+    pub bytes: Vec<u8>,
+}
+
+impl StructValue {
+    /// Creates a new `StructValue`.
+    pub fn new(type_name: impl Into<String>, bytes: impl Into<Vec<u8>>) -> Self {
+        Self {
+            type_name: type_name.into(),
+            bytes: bytes.into(),
+        }
+    }
+}
+
 /// CEL opaque value type.
 pub type OpaqueValue = Box<dyn Opaque>;
 
@@ -278,8 +301,8 @@ pub enum Value {
     /// Byte array
     Bytes(BytesValue),
 
-    /// Struct (not yet implemented)
-    Struct(()),
+    /// Struct (Protocol Buffers message)
+    Struct(StructValue),
 
     /// Duration (Protocol Buffers Duration)
     Duration(Duration),
@@ -382,8 +405,8 @@ impl Value {
             Value::Double(_) => ValueType::Double,
             Value::String(_) => ValueType::String,
             Value::Bytes(_) => ValueType::Bytes,
-            Value::Struct(_s) => {
-                todo!()
+            Value::Struct(s) => {
+                ValueType::Struct(crate::types::StructType::new(&s.type_name))
             }
             Value::Duration(_) => ValueType::Duration,
             Value::Timestamp(_) => ValueType::Timestamp,
@@ -574,10 +597,34 @@ impl Value {
     }
 
     /// Returns the struct value if this value is a struct value.
-    pub fn as_struct(&self) -> Option<&()> {
+    pub fn as_struct(&self) -> Option<&StructValue> {
         match self {
             Value::Struct(s) => Some(s),
             _ => None,
+        }
+    }
+
+    /// Extracts the protobuf type name and serialized bytes from a struct value.
+    ///
+    /// Returns an error if this value is not a `Value::Struct`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use cel_cxx::Value;
+    /// # fn example(result: Value) -> Result<(), cel_cxx::Error> {
+    /// let (type_name, bytes) = result.as_protobuf_bytes()?;
+    /// assert_eq!(type_name, "my.package.MyMessage");
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn as_protobuf_bytes(&self) -> Result<(&str, &[u8]), Error> {
+        match self {
+            Value::Struct(s) => Ok((&s.type_name, &s.bytes)),
+            _ => Err(Error::invalid_argument(format!(
+                "expected struct value, got {}",
+                self.value_type()
+            ))),
         }
     }
 
@@ -702,7 +749,7 @@ impl Value {
     }
 
     /// Returns a mutable reference to the struct value if this value is a struct value.
-    pub fn as_struct_mut(&mut self) -> Option<&mut ()> {
+    pub fn as_struct_mut(&mut self) -> Option<&mut StructValue> {
         match self {
             Value::Struct(s) => Some(s),
             _ => None,
@@ -838,7 +885,7 @@ impl Value {
     }
 
     /// Converts the value to a struct value.
-    pub fn into_struct(self) -> Option<()> {
+    pub fn into_struct(self) -> Option<StructValue> {
         match self {
             Value::Struct(s) => Some(s),
             _ => None,
@@ -974,7 +1021,7 @@ impl Value {
     }
 
     /// Converts the value to a struct value and panics if the value is not a struct value.
-    pub fn unwrap_struct(self) {
+    pub fn unwrap_struct(self) -> StructValue {
         match self {
             Value::Struct(s) => s,
             _ => panic!("called `Value::unwrap_struct()` on a non-struct value: {self:?}",),
@@ -1110,7 +1157,7 @@ impl Value {
     }
 
     /// Converts the value to a struct value and panics if the value is not a struct value.
-    pub fn expect_struct(self, msg: &str) {
+    pub fn expect_struct(self, msg: &str) -> StructValue {
         match self {
             Value::Struct(s) => s,
             _ => panic!("{msg}: {self:?}"),

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -24,7 +24,7 @@
 //! ## Composite Types
 //! - **List**: Ordered collections of values (`Vec<Value>`)
 //! - **Map**: Key-value mappings (`HashMap<MapKey, Value>`)
-//! - **Struct**: Protocol Buffers message types (not yet implemented)
+//! - **Struct**: Serialized message types (e.g. Protocol Buffers messages)
 //! - **Optional**: Wrapper for optional values
 //!
 //! ## Special Types
@@ -204,26 +204,43 @@ pub type ListValue = Vec<Value>;
 /// CEL map value type.
 pub type MapValue = HashMap<MapKey, Value>;
 
-/// CEL struct value representing a Protocol Buffers message.
+/// CEL struct value representing a serialized message.
 ///
 /// The message is stored as its fully-qualified type name plus serialized bytes.
 /// Deserialization into C++ `MessageValue` happens at the FFI boundary when the
 /// value is passed to cel-cpp for evaluation.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct StructValue {
-    /// The fully qualified protobuf message type name (e.g. `"my.package.MyMessage"`).
-    pub type_name: String,
-    /// The serialized protobuf bytes of the message.
-    pub bytes: Vec<u8>,
+    type_name: String,
+    bytes: Vec<u8>,
 }
 
 impl StructValue {
-    /// Creates a new `StructValue`.
-    pub fn new(type_name: impl Into<String>, bytes: impl Into<Vec<u8>>) -> Self {
+    /// Creates a new `StructValue` from a type name and serialized bytes.
+    pub fn from_bytes(type_name: impl Into<String>, bytes: impl Into<Vec<u8>>) -> Self {
         Self {
             type_name: type_name.into(),
             bytes: bytes.into(),
         }
+    }
+
+    /// Returns the fully qualified message type name (e.g. `"my.package.MyMessage"`).
+    pub fn type_name(&self) -> &str {
+        &self.type_name
+    }
+
+    /// Returns the serialized bytes of the message.
+    pub fn to_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+impl std::fmt::Debug for StructValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StructValue")
+            .field("type_name", &self.type_name())
+            .field("bytes_len", &self.to_bytes().len())
+            .finish()
     }
 }
 
@@ -301,7 +318,7 @@ pub enum Value {
     /// Byte array
     Bytes(BytesValue),
 
-    /// Struct (Protocol Buffers message)
+    /// Struct (serialized message)
     Struct(StructValue),
 
     /// Duration (Protocol Buffers Duration)
@@ -406,7 +423,7 @@ impl Value {
             Value::String(_) => ValueType::String,
             Value::Bytes(_) => ValueType::Bytes,
             Value::Struct(s) => {
-                ValueType::Struct(crate::types::StructType::new(&s.type_name))
+                ValueType::Struct(crate::types::StructType::new(s.type_name()))
             }
             Value::Duration(_) => ValueType::Duration,
             Value::Timestamp(_) => ValueType::Timestamp,
@@ -604,30 +621,6 @@ impl Value {
         }
     }
 
-    /// Extracts the protobuf type name and serialized bytes from a struct value.
-    ///
-    /// Returns an error if this value is not a `Value::Struct`.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,no_run
-    /// # use cel_cxx::Value;
-    /// # fn example(result: Value) -> Result<(), cel_cxx::Error> {
-    /// let (type_name, bytes) = result.as_protobuf_bytes()?;
-    /// assert_eq!(type_name, "my.package.MyMessage");
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn as_protobuf_bytes(&self) -> Result<(&str, &[u8]), Error> {
-        match self {
-            Value::Struct(s) => Ok((&s.type_name, &s.bytes)),
-            _ => Err(Error::invalid_argument(format!(
-                "expected struct value, got {}",
-                self.value_type()
-            ))),
-        }
-    }
-
     /// Returns the duration value if this value is a duration value.
     pub fn as_duration(&self) -> Option<&Duration> {
         match self {
@@ -744,14 +737,6 @@ impl Value {
     pub fn as_bytes_mut(&mut self) -> Option<&mut BytesValue> {
         match self {
             Value::Bytes(b) => Some(b),
-            _ => None,
-        }
-    }
-
-    /// Returns a mutable reference to the struct value if this value is a struct value.
-    pub fn as_struct_mut(&mut self) -> Option<&mut StructValue> {
-        match self {
-            Value::Struct(s) => Some(s),
             _ => None,
         }
     }

--- a/src/variable/bindings.rs
+++ b/src/variable/bindings.rs
@@ -106,6 +106,22 @@ impl<'f> VariableBindings<'f> {
         Ok(self)
     }
 
+    /// Binds a variable with an explicit type and pre-converted value.
+    ///
+    /// Unlike [`bind`](Self::bind) which infers the type from the value, this method
+    /// takes the type and value separately. This is useful for types like protobuf
+    /// messages where the concrete type name is not known at compile time.
+    pub fn bind_with_value(
+        &mut self,
+        name: impl Into<String>,
+        value_type: ValueType,
+        value: Value,
+    ) -> Result<&mut Self, Error> {
+        self.entries
+            .insert(name.into(), VariableBinding::Value((value_type, value)));
+        Ok(self)
+    }
+
     /// Binds a variable to a value provider.
     ///
     /// Binds a variable name to a provider function that computes the value dynamically.

--- a/src/variable/registry.rs
+++ b/src/variable/registry.rs
@@ -146,6 +146,30 @@ impl VariableRegistry {
         Ok(self)
     }
 
+    /// Declares a variable with an explicit type.
+    ///
+    /// Unlike [`declare`](Self::declare) which infers the type from a generic parameter,
+    /// this method takes a [`ValueType`] directly. This is useful for types that
+    /// cannot be expressed via the `TypedValue` trait, such as protobuf message types.
+    ///
+    /// # Parameters
+    ///
+    /// - `name`: The variable name
+    /// - `value_type`: The explicit type for this variable
+    ///
+    /// # Returns
+    ///
+    /// Returns `&mut Self` to support method chaining, or [`Error`] if an error occurs
+    pub fn declare_with_type(
+        &mut self,
+        name: impl Into<String>,
+        value_type: ValueType,
+    ) -> Result<&mut Self, Error> {
+        self.entries
+            .insert(name.into(), VariableDeclOrConstant::new(value_type));
+        Ok(self)
+    }
+
     /// Returns an iterator over all variable entries.
     ///
     /// The iterator yields `(name, entry)` pairs for all registered variables and constants.

--- a/tests/fixtures/test.proto
+++ b/tests/fixtures/test.proto
@@ -1,0 +1,60 @@
+// Compiled at runtime using protox (pure-Rust protobuf compiler).
+// No pre-compiled binary needed.
+
+syntax = "proto3";
+
+package test;
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
+import "google/protobuf/any.proto";
+import "google/protobuf/struct.proto";
+
+message SimpleMessage {
+  string name = 1;
+  int32 id = 2;
+}
+
+enum Status {
+  STATUS_UNSPECIFIED = 0;
+  STATUS_ACTIVE = 1;
+  STATUS_INACTIVE = 2;
+}
+
+message Address {
+  string street = 1;
+  string city = 2;
+  string zip = 3;
+}
+
+message Person {
+  string name = 1;
+  int32 age = 2;
+  Address address = 3;
+  Status status = 4;
+  repeated string tags = 5;
+  bool active = 6;
+}
+
+message Item {
+  string name = 1;
+  int32 price = 2;
+}
+
+message Order {
+  Person buyer = 1;
+  repeated Item items = 2;
+  map<string, string> labels = 3;
+}
+
+message Event {
+  string name = 1;
+  google.protobuf.Timestamp created_at = 2;
+  google.protobuf.Duration ttl = 3;
+  google.protobuf.Int64Value optional_count = 4;
+  google.protobuf.StringValue optional_label = 5;
+  google.protobuf.BoolValue optional_flag = 6;
+  google.protobuf.Struct metadata = 7;
+  google.protobuf.Any payload = 8;
+}

--- a/tests/prost_derive.rs
+++ b/tests/prost_derive.rs
@@ -1,0 +1,212 @@
+#![cfg(feature = "prost")]
+
+use cel_cxx::*;
+use std::sync::LazyLock;
+
+// Import prost-generated types (with ProstValue derived via build.rs)
+include!(concat!(env!("OUT_DIR"), "/test.rs"));
+
+static TEST_DESCRIPTORS: LazyLock<Vec<u8>> = LazyLock::new(|| {
+    use prost::Message;
+    protox::compile(["tests/fixtures/test.proto"], ["tests/fixtures/"])
+        .unwrap()
+        .encode_to_vec()
+});
+
+// --- TypedValue ---
+
+#[test]
+fn test_typed_value_returns_struct_type() {
+    let vt = <SimpleMessage as TypedValue>::value_type();
+    assert_eq!(vt, ValueType::Struct(StructType::new("test.SimpleMessage")));
+}
+
+#[test]
+fn test_typed_value_nested_type() {
+    let vt = <Person as TypedValue>::value_type();
+    assert_eq!(vt, ValueType::Struct(StructType::new("test.Person")));
+}
+
+// --- IntoValue ---
+
+#[test]
+fn test_into_value_produces_struct() {
+    let msg = SimpleMessage {
+        name: "hello".into(),
+        id: 42,
+    };
+    let value = msg.into_value();
+    match &value {
+        Value::Struct(sv) => {
+            assert_eq!(sv.type_name(), "test.SimpleMessage");
+            assert!(!sv.to_bytes().is_empty());
+        }
+        other => panic!("expected Value::Struct, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_from_trait_conversion() {
+    let msg = SimpleMessage {
+        name: "test".into(),
+        id: 1,
+    };
+    let value: Value = msg.into();
+    assert!(matches!(value, Value::Struct(_)));
+}
+
+// --- FromValue ---
+
+#[test]
+fn test_from_value_roundtrip() {
+    let original = SimpleMessage {
+        name: "roundtrip".into(),
+        id: 99,
+    };
+    let value = original.clone().into_value();
+    let recovered = SimpleMessage::from_value(&value).unwrap();
+    assert_eq!(recovered, original);
+}
+
+#[test]
+fn test_try_from_value_owned() {
+    let msg = SimpleMessage {
+        name: "try".into(),
+        id: 7,
+    };
+    let value = msg.clone().into_value();
+    let recovered = SimpleMessage::try_from(value).unwrap();
+    assert_eq!(recovered, msg);
+}
+
+#[test]
+fn test_try_from_value_ref() {
+    let msg = SimpleMessage {
+        name: "ref".into(),
+        id: 8,
+    };
+    let value = msg.clone().into_value();
+    let recovered = SimpleMessage::try_from(&value).unwrap();
+    assert_eq!(recovered, msg);
+}
+
+#[test]
+fn test_from_value_wrong_type_returns_error() {
+    let value = Value::Int(42);
+    let result = SimpleMessage::from_value(&value);
+    assert!(result.is_err());
+}
+
+// --- Full CEL integration ---
+
+#[test]
+fn test_declare_and_bind_prost_message() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_variable::<SimpleMessage>("msg")?
+        .build()?;
+
+    let program = env.compile("msg.name")?;
+
+    let msg = SimpleMessage {
+        name: "Alice".into(),
+        id: 1,
+    };
+    let activation = Activation::new().bind_variable("msg", msg)?;
+
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::String("Alice".into()));
+    Ok(())
+}
+
+#[test]
+fn test_cel_field_access_int() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_variable::<SimpleMessage>("msg")?
+        .build()?;
+
+    let program = env.compile("msg.id")?;
+
+    let msg = SimpleMessage {
+        name: "Bob".into(),
+        id: 42,
+    };
+    let activation = Activation::new().bind_variable("msg", msg)?;
+
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Int(42));
+    Ok(())
+}
+
+#[test]
+fn test_nested_message_roundtrip() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_variable::<Person>("p")?
+        .build()?;
+
+    let program = env.compile("p.address.city")?;
+
+    let person = Person {
+        name: "Charlie".into(),
+        age: 30,
+        address: Some(Address {
+            street: "123 Main St".into(),
+            city: "Springfield".into(),
+            zip: "62701".into(),
+        }),
+        status: Status::Active as i32,
+        tags: vec!["admin".into()],
+        active: true,
+    };
+    let activation = Activation::new().bind_variable("p", person)?;
+
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::String("Springfield".into()));
+    Ok(())
+}
+
+#[test]
+fn test_cel_eval_returns_message_and_from_value() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_variable::<SimpleMessage>("msg")?
+        .build()?;
+
+    // CEL can construct messages using Type{field: value} syntax
+    let program = env.compile("test.SimpleMessage{name: 'constructed', id: 100}")?;
+    let result = program.evaluate(&Activation::new())?;
+
+    let recovered = SimpleMessage::from_value(&result).unwrap();
+    assert_eq!(recovered.name, "constructed");
+    assert_eq!(recovered.id, 100);
+    Ok(())
+}
+
+// --- type_name override ---
+
+#[derive(Clone, PartialEq, prost::Message, cel_cxx::ProstValue)]
+#[cel_cxx(type_name = "custom.OverriddenType")]
+pub struct CustomTypeNameMsg {
+    #[prost(string, tag = "1")]
+    pub data: String,
+}
+
+#[test]
+fn test_type_name_override() {
+    let vt = <CustomTypeNameMsg as TypedValue>::value_type();
+    assert_eq!(
+        vt,
+        ValueType::Struct(StructType::new("custom.OverriddenType"))
+    );
+
+    let msg = CustomTypeNameMsg {
+        data: "test".into(),
+    };
+    let value = msg.into_value();
+    match &value {
+        Value::Struct(sv) => assert_eq!(sv.type_name(), "custom.OverriddenType"),
+        other => panic!("expected Value::Struct, got {other:?}"),
+    }
+}

--- a/tests/protobuf.rs
+++ b/tests/protobuf.rs
@@ -303,18 +303,17 @@ fn encode_event(
 }
 
 #[test]
-fn test_bind_protobuf_variable_field_access() -> Result<(), Error> {
+fn test_bind_variable_dynamic_field_access() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("msg", "test.SimpleMessage")?
+        .declare_variable_with_type("msg", ValueType::Struct(StructType::new("test.SimpleMessage")))?
         .build()?;
 
     let bytes = encode_simple_message("Alice", 42);
 
-    let activation = Activation::new().bind_protobuf_variable(
+    let activation = Activation::new().bind_variable_dynamic(
         "msg",
-        "test.SimpleMessage",
-        &bytes,
+        StructValue::from_bytes("test.SimpleMessage", bytes.as_slice()),
     )?;
 
     // Test string field access
@@ -339,15 +338,14 @@ fn test_bind_protobuf_variable_field_access() -> Result<(), Error> {
 fn test_protobuf_value_roundtrip() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("msg", "test.SimpleMessage")?
+        .declare_variable_with_type("msg", ValueType::Struct(StructType::new("test.SimpleMessage")))?
         .build()?;
 
     let bytes = encode_simple_message("Bob", 99);
 
-    let activation = Activation::new().bind_protobuf_variable(
+    let activation = Activation::new().bind_variable_dynamic(
         "msg",
-        "test.SimpleMessage",
-        &bytes,
+        StructValue::from_bytes("test.SimpleMessage", bytes.as_slice()),
     )?;
 
     // Evaluate `msg` directly — should get a Value::Struct back
@@ -356,9 +354,9 @@ fn test_protobuf_value_roundtrip() -> Result<(), Error> {
 
     match &result {
         Value::Struct(s) => {
-            assert_eq!(s.type_name, "test.SimpleMessage");
+            assert_eq!(s.type_name(), "test.SimpleMessage");
             // The bytes should round-trip (serialize the same message back)
-            assert!(!s.bytes.is_empty());
+            assert!(!s.to_bytes().is_empty());
         }
         other => panic!("Expected Value::Struct, got: {other:?}"),
     }
@@ -370,15 +368,14 @@ fn test_protobuf_value_roundtrip() -> Result<(), Error> {
 fn test_protobuf_field_access_string_result() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("msg", "test.SimpleMessage")?
+        .declare_variable_with_type("msg", ValueType::Struct(StructType::new("test.SimpleMessage")))?
         .build()?;
 
     let bytes = encode_simple_message("Charlie", 7);
 
-    let activation = Activation::new().bind_protobuf_variable(
+    let activation = Activation::new().bind_variable_dynamic(
         "msg",
-        "test.SimpleMessage",
-        &bytes,
+        StructValue::from_bytes("test.SimpleMessage", bytes.as_slice()),
     )?;
 
     // Access a string field directly
@@ -404,14 +401,14 @@ fn test_protobuf_field_access_string_result() -> Result<(), Error> {
 fn test_scalar_bool_field() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("person", "test.Person")?
+        .declare_variable_with_type("person", ValueType::Struct(StructType::new("test.Person")))?
         .build()?;
 
     let addr = encode_address("123 Main St", "Springfield", "62704");
     let bytes = encode_person("Alice", 30, Some(&addr), 1, &["rust"], true);
 
     let activation =
-        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+        Activation::new().bind_variable_dynamic("person", StructValue::from_bytes("test.Person", bytes.as_slice()))?;
 
     let program = env.compile("person.active == true")?;
     let result = program.evaluate(&activation)?;
@@ -424,14 +421,14 @@ fn test_scalar_bool_field() -> Result<(), Error> {
 fn test_scalar_default_values() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("person", "test.Person")?
+        .declare_variable_with_type("person", ValueType::Struct(StructType::new("test.Person")))?
         .build()?;
 
     // Empty person — all fields at defaults
     let bytes = encode_person("", 0, None, 0, &[], false);
 
     let activation =
-        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+        Activation::new().bind_variable_dynamic("person", StructValue::from_bytes("test.Person", bytes.as_slice()))?;
 
     let program = env.compile("person.age == 0 && person.active == false")?;
     let result = program.evaluate(&activation)?;
@@ -446,14 +443,14 @@ fn test_scalar_default_values() -> Result<(), Error> {
 fn test_nested_message_field_access() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("person", "test.Person")?
+        .declare_variable_with_type("person", ValueType::Struct(StructType::new("test.Person")))?
         .build()?;
 
     let addr = encode_address("456 Market St", "San Francisco", "94105");
     let bytes = encode_person("Bob", 25, Some(&addr), 0, &[], false);
 
     let activation =
-        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+        Activation::new().bind_variable_dynamic("person", StructValue::from_bytes("test.Person", bytes.as_slice()))?;
 
     let program = env.compile("person.address.city == 'San Francisco'")?;
     let result = program.evaluate(&activation)?;
@@ -466,7 +463,7 @@ fn test_nested_message_field_access() -> Result<(), Error> {
 fn test_deeply_nested_field_access() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("order", "test.Order")?
+        .declare_variable_with_type("order", ValueType::Struct(StructType::new("test.Order")))?
         .build()?;
 
     let addr = encode_address("789 Broadway", "NYC", "10001");
@@ -474,7 +471,7 @@ fn test_deeply_nested_field_access() -> Result<(), Error> {
     let bytes = encode_order(Some(&buyer), &[], &[]);
 
     let activation =
-        Activation::new().bind_protobuf_variable("order", "test.Order", &bytes)?;
+        Activation::new().bind_variable_dynamic("order", StructValue::from_bytes("test.Order", bytes.as_slice()))?;
 
     let program = env.compile("order.buyer.address.city == 'NYC'")?;
     let result = program.evaluate(&activation)?;
@@ -489,13 +486,13 @@ fn test_deeply_nested_field_access() -> Result<(), Error> {
 fn test_repeated_string_size() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("person", "test.Person")?
+        .declare_variable_with_type("person", ValueType::Struct(StructType::new("test.Person")))?
         .build()?;
 
     let bytes = encode_person("Dave", 28, None, 0, &["rust", "cel", "proto"], false);
 
     let activation =
-        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+        Activation::new().bind_variable_dynamic("person", StructValue::from_bytes("test.Person", bytes.as_slice()))?;
 
     let program = env.compile("person.tags.size() == 3")?;
     let result = program.evaluate(&activation)?;
@@ -508,13 +505,13 @@ fn test_repeated_string_size() -> Result<(), Error> {
 fn test_repeated_string_index() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("person", "test.Person")?
+        .declare_variable_with_type("person", ValueType::Struct(StructType::new("test.Person")))?
         .build()?;
 
     let bytes = encode_person("Dave", 28, None, 0, &["rust", "cel", "proto"], false);
 
     let activation =
-        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+        Activation::new().bind_variable_dynamic("person", StructValue::from_bytes("test.Person", bytes.as_slice()))?;
 
     let program = env.compile("person.tags[0] == 'rust'")?;
     let result = program.evaluate(&activation)?;
@@ -527,13 +524,13 @@ fn test_repeated_string_index() -> Result<(), Error> {
 fn test_repeated_string_exists() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("person", "test.Person")?
+        .declare_variable_with_type("person", ValueType::Struct(StructType::new("test.Person")))?
         .build()?;
 
     let bytes = encode_person("Dave", 28, None, 0, &["rust", "cel", "proto"], false);
 
     let activation =
-        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+        Activation::new().bind_variable_dynamic("person", StructValue::from_bytes("test.Person", bytes.as_slice()))?;
 
     let program = env.compile("person.tags.exists(t, t == 'cel')")?;
     let result = program.evaluate(&activation)?;
@@ -546,7 +543,7 @@ fn test_repeated_string_exists() -> Result<(), Error> {
 fn test_repeated_message_field() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("order", "test.Order")?
+        .declare_variable_with_type("order", ValueType::Struct(StructType::new("test.Order")))?
         .build()?;
 
     let item1 = encode_item("Widget", 100);
@@ -554,7 +551,7 @@ fn test_repeated_message_field() -> Result<(), Error> {
     let bytes = encode_order(None, &[&item1, &item2], &[]);
 
     let activation =
-        Activation::new().bind_protobuf_variable("order", "test.Order", &bytes)?;
+        Activation::new().bind_variable_dynamic("order", StructValue::from_bytes("test.Order", bytes.as_slice()))?;
 
     let program = env.compile("order.items[0].name == 'Widget'")?;
     let result = program.evaluate(&activation)?;
@@ -567,7 +564,7 @@ fn test_repeated_message_field() -> Result<(), Error> {
 fn test_repeated_message_exists() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("order", "test.Order")?
+        .declare_variable_with_type("order", ValueType::Struct(StructType::new("test.Order")))?
         .build()?;
 
     let item1 = encode_item("Widget", 100);
@@ -575,7 +572,7 @@ fn test_repeated_message_exists() -> Result<(), Error> {
     let bytes = encode_order(None, &[&item1, &item2], &[]);
 
     let activation =
-        Activation::new().bind_protobuf_variable("order", "test.Order", &bytes)?;
+        Activation::new().bind_variable_dynamic("order", StructValue::from_bytes("test.Order", bytes.as_slice()))?;
 
     let program = env.compile("order.items.exists(i, i.price > 200)")?;
     let result = program.evaluate(&activation)?;
@@ -588,13 +585,13 @@ fn test_repeated_message_exists() -> Result<(), Error> {
 fn test_repeated_empty() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("person", "test.Person")?
+        .declare_variable_with_type("person", ValueType::Struct(StructType::new("test.Person")))?
         .build()?;
 
     let bytes = encode_person("Eve", 22, None, 0, &[], false);
 
     let activation =
-        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+        Activation::new().bind_variable_dynamic("person", StructValue::from_bytes("test.Person", bytes.as_slice()))?;
 
     let program = env.compile("person.tags.size() == 0")?;
     let result = program.evaluate(&activation)?;
@@ -609,13 +606,13 @@ fn test_repeated_empty() -> Result<(), Error> {
 fn test_map_field_access() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("order", "test.Order")?
+        .declare_variable_with_type("order", ValueType::Struct(StructType::new("test.Order")))?
         .build()?;
 
     let bytes = encode_order(None, &[], &[("env", "prod"), ("region", "us-east")]);
 
     let activation =
-        Activation::new().bind_protobuf_variable("order", "test.Order", &bytes)?;
+        Activation::new().bind_variable_dynamic("order", StructValue::from_bytes("test.Order", bytes.as_slice()))?;
 
     let program = env.compile(r#"order.labels["env"] == "prod""#)?;
     let result = program.evaluate(&activation)?;
@@ -628,13 +625,13 @@ fn test_map_field_access() -> Result<(), Error> {
 fn test_map_contains_key() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("order", "test.Order")?
+        .declare_variable_with_type("order", ValueType::Struct(StructType::new("test.Order")))?
         .build()?;
 
     let bytes = encode_order(None, &[], &[("env", "prod"), ("region", "us-east")]);
 
     let activation =
-        Activation::new().bind_protobuf_variable("order", "test.Order", &bytes)?;
+        Activation::new().bind_variable_dynamic("order", StructValue::from_bytes("test.Order", bytes.as_slice()))?;
 
     let program = env.compile(r#""env" in order.labels"#)?;
     let result = program.evaluate(&activation)?;
@@ -647,13 +644,13 @@ fn test_map_contains_key() -> Result<(), Error> {
 fn test_map_size() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("order", "test.Order")?
+        .declare_variable_with_type("order", ValueType::Struct(StructType::new("test.Order")))?
         .build()?;
 
     let bytes = encode_order(None, &[], &[("env", "prod"), ("region", "us-east")]);
 
     let activation =
-        Activation::new().bind_protobuf_variable("order", "test.Order", &bytes)?;
+        Activation::new().bind_variable_dynamic("order", StructValue::from_bytes("test.Order", bytes.as_slice()))?;
 
     let program = env.compile("order.labels.size() == 2")?;
     let result = program.evaluate(&activation)?;
@@ -668,14 +665,14 @@ fn test_map_size() -> Result<(), Error> {
 fn test_enum_field_as_int() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("person", "test.Person")?
+        .declare_variable_with_type("person", ValueType::Struct(StructType::new("test.Person")))?
         .build()?;
 
     // status = STATUS_ACTIVE = 1
     let bytes = encode_person("Frank", 35, None, 1, &[], false);
 
     let activation =
-        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+        Activation::new().bind_variable_dynamic("person", StructValue::from_bytes("test.Person", bytes.as_slice()))?;
 
     let program = env.compile("person.status == 1")?;
     let result = program.evaluate(&activation)?;
@@ -688,14 +685,14 @@ fn test_enum_field_as_int() -> Result<(), Error> {
 fn test_enum_field_named_constant() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("person", "test.Person")?
+        .declare_variable_with_type("person", ValueType::Struct(StructType::new("test.Person")))?
         .build()?;
 
     // status = STATUS_ACTIVE = 1
     let bytes = encode_person("Grace", 29, None, 1, &[], false);
 
     let activation =
-        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+        Activation::new().bind_variable_dynamic("person", StructValue::from_bytes("test.Person", bytes.as_slice()))?;
 
     let program = env.compile("person.status == test.Status.STATUS_ACTIVE")?;
     let result = program.evaluate(&activation)?;
@@ -708,14 +705,14 @@ fn test_enum_field_named_constant() -> Result<(), Error> {
 fn test_enum_field_default() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("person", "test.Person")?
+        .declare_variable_with_type("person", ValueType::Struct(StructType::new("test.Person")))?
         .build()?;
 
     // status = STATUS_UNSPECIFIED = 0 (default)
     let bytes = encode_person("Hank", 50, None, 0, &[], false);
 
     let activation =
-        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+        Activation::new().bind_variable_dynamic("person", StructValue::from_bytes("test.Person", bytes.as_slice()))?;
 
     let program = env.compile("person.status == 0")?;
     let result = program.evaluate(&activation)?;
@@ -734,14 +731,14 @@ fn test_enum_field_default() -> Result<(), Error> {
 fn test_wkt_duration_field() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("event", "test.Event")?
+        .declare_variable_with_type("event", ValueType::Struct(StructType::new("test.Event")))?
         .build()?;
 
     let ttl = encode_duration(3600, 0);
     let bytes = encode_event("test", None, Some(&ttl), None, None, None, None, None);
 
     let activation =
-        Activation::new().bind_protobuf_variable("event", "test.Event", &bytes)?;
+        Activation::new().bind_variable_dynamic("event", StructValue::from_bytes("test.Event", bytes.as_slice()))?;
 
     let program = env.compile("event.ttl == duration('3600s')")?;
     let result = program.evaluate(&activation)?;
@@ -754,14 +751,14 @@ fn test_wkt_duration_field() -> Result<(), Error> {
 fn test_wkt_duration_comparison() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("event", "test.Event")?
+        .declare_variable_with_type("event", ValueType::Struct(StructType::new("test.Event")))?
         .build()?;
 
     let ttl = encode_duration(3600, 0); // 1 hour
     let bytes = encode_event("test", None, Some(&ttl), None, None, None, None, None);
 
     let activation =
-        Activation::new().bind_protobuf_variable("event", "test.Event", &bytes)?;
+        Activation::new().bind_variable_dynamic("event", StructValue::from_bytes("test.Event", bytes.as_slice()))?;
 
     // 30m = 1800s, so 3600s > 1800s
     let program = env.compile("event.ttl > duration('1800s')")?;
@@ -777,7 +774,7 @@ fn test_wkt_duration_comparison() -> Result<(), Error> {
 fn test_wkt_timestamp_field() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("event", "test.Event")?
+        .declare_variable_with_type("event", ValueType::Struct(StructType::new("test.Event")))?
         .build()?;
 
     // 2024-01-01T00:00:00Z = 1704067200 seconds since epoch
@@ -785,7 +782,7 @@ fn test_wkt_timestamp_field() -> Result<(), Error> {
     let bytes = encode_event("test", Some(&created_at), None, None, None, None, None, None);
 
     let activation =
-        Activation::new().bind_protobuf_variable("event", "test.Event", &bytes)?;
+        Activation::new().bind_variable_dynamic("event", StructValue::from_bytes("test.Event", bytes.as_slice()))?;
 
     let program = env.compile("event.created_at == timestamp('2024-01-01T00:00:00Z')")?;
     let result = program.evaluate(&activation)?;
@@ -798,7 +795,7 @@ fn test_wkt_timestamp_field() -> Result<(), Error> {
 fn test_wkt_timestamp_comparison() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("event", "test.Event")?
+        .declare_variable_with_type("event", ValueType::Struct(StructType::new("test.Event")))?
         .build()?;
 
     // 2024-01-01T00:00:00Z
@@ -806,7 +803,7 @@ fn test_wkt_timestamp_comparison() -> Result<(), Error> {
     let bytes = encode_event("test", Some(&created_at), None, None, None, None, None, None);
 
     let activation =
-        Activation::new().bind_protobuf_variable("event", "test.Event", &bytes)?;
+        Activation::new().bind_variable_dynamic("event", StructValue::from_bytes("test.Event", bytes.as_slice()))?;
 
     let program = env.compile("event.created_at > timestamp('2023-01-01T00:00:00Z')")?;
     let result = program.evaluate(&activation)?;
@@ -821,14 +818,14 @@ fn test_wkt_timestamp_comparison() -> Result<(), Error> {
 fn test_wkt_int64_wrapper() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("event", "test.Event")?
+        .declare_variable_with_type("event", ValueType::Struct(StructType::new("test.Event")))?
         .build()?;
 
     let count = encode_int64_value(42);
     let bytes = encode_event("test", None, None, Some(&count), None, None, None, None);
 
     let activation =
-        Activation::new().bind_protobuf_variable("event", "test.Event", &bytes)?;
+        Activation::new().bind_variable_dynamic("event", StructValue::from_bytes("test.Event", bytes.as_slice()))?;
 
     let program = env.compile("event.optional_count == 42")?;
     let result = program.evaluate(&activation)?;
@@ -841,14 +838,14 @@ fn test_wkt_int64_wrapper() -> Result<(), Error> {
 fn test_wkt_string_wrapper() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("event", "test.Event")?
+        .declare_variable_with_type("event", ValueType::Struct(StructType::new("test.Event")))?
         .build()?;
 
     let label = encode_string_value("important");
     let bytes = encode_event("test", None, None, None, Some(&label), None, None, None);
 
     let activation =
-        Activation::new().bind_protobuf_variable("event", "test.Event", &bytes)?;
+        Activation::new().bind_variable_dynamic("event", StructValue::from_bytes("test.Event", bytes.as_slice()))?;
 
     let program = env.compile("event.optional_label == 'important'")?;
     let result = program.evaluate(&activation)?;
@@ -861,14 +858,14 @@ fn test_wkt_string_wrapper() -> Result<(), Error> {
 fn test_wkt_bool_wrapper() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("event", "test.Event")?
+        .declare_variable_with_type("event", ValueType::Struct(StructType::new("test.Event")))?
         .build()?;
 
     let flag = encode_bool_value(true);
     let bytes = encode_event("test", None, None, None, None, Some(&flag), None, None);
 
     let activation =
-        Activation::new().bind_protobuf_variable("event", "test.Event", &bytes)?;
+        Activation::new().bind_variable_dynamic("event", StructValue::from_bytes("test.Event", bytes.as_slice()))?;
 
     let program = env.compile("event.optional_flag == true")?;
     let result = program.evaluate(&activation)?;
@@ -883,14 +880,14 @@ fn test_wkt_bool_wrapper() -> Result<(), Error> {
 fn test_wkt_struct_field_access() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("event", "test.Event")?
+        .declare_variable_with_type("event", ValueType::Struct(StructType::new("test.Event")))?
         .build()?;
 
     let metadata = encode_struct_with_string_values(&[("env", "prod"), ("version", "1.0")]);
     let bytes = encode_event("test", None, None, None, None, None, Some(&metadata), None);
 
     let activation =
-        Activation::new().bind_protobuf_variable("event", "test.Event", &bytes)?;
+        Activation::new().bind_variable_dynamic("event", StructValue::from_bytes("test.Event", bytes.as_slice()))?;
 
     let program = env.compile("event.metadata.env == 'prod'")?;
     let result = program.evaluate(&activation)?;
@@ -903,14 +900,14 @@ fn test_wkt_struct_field_access() -> Result<(), Error> {
 fn test_wkt_struct_has_key() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("event", "test.Event")?
+        .declare_variable_with_type("event", ValueType::Struct(StructType::new("test.Event")))?
         .build()?;
 
     let metadata = encode_struct_with_string_values(&[("env", "prod"), ("version", "1.0")]);
     let bytes = encode_event("test", None, None, None, None, None, Some(&metadata), None);
 
     let activation =
-        Activation::new().bind_protobuf_variable("event", "test.Event", &bytes)?;
+        Activation::new().bind_variable_dynamic("event", StructValue::from_bytes("test.Event", bytes.as_slice()))?;
 
     let program = env.compile("has(event.metadata.env)")?;
     let result = program.evaluate(&activation)?;
@@ -925,7 +922,7 @@ fn test_wkt_struct_has_key() -> Result<(), Error> {
 fn test_wkt_any_type_url() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("event", "test.Event")?
+        .declare_variable_with_type("event", ValueType::Struct(StructType::new("test.Event")))?
         .build()?;
 
     // Pack a SimpleMessage into Any
@@ -934,7 +931,7 @@ fn test_wkt_any_type_url() -> Result<(), Error> {
     let bytes = encode_event("test", None, None, None, None, None, None, Some(&payload));
 
     let activation =
-        Activation::new().bind_protobuf_variable("event", "test.Event", &bytes)?;
+        Activation::new().bind_variable_dynamic("event", StructValue::from_bytes("test.Event", bytes.as_slice()))?;
 
     // Try to check if the Any field is present via has()
     let program = env.compile("has(event.payload)")?;
@@ -949,38 +946,37 @@ fn test_wkt_any_type_url() -> Result<(), Error> {
 // =============================================================================
 
 #[test]
-fn test_as_protobuf_bytes() -> Result<(), Error> {
+fn test_as_struct_accessors() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("msg", "test.SimpleMessage")?
+        .declare_variable_with_type("msg", ValueType::Struct(StructType::new("test.SimpleMessage")))?
         .build()?;
 
     let bytes = encode_simple_message("Alice", 42);
 
-    let activation = Activation::new().bind_protobuf_variable(
+    let activation = Activation::new().bind_variable_dynamic(
         "msg",
-        "test.SimpleMessage",
-        &bytes,
+        StructValue::from_bytes("test.SimpleMessage", bytes.as_slice()),
     )?;
 
     let program = env.compile("msg")?;
     let result = program.evaluate(&activation)?;
 
-    let (type_name, result_bytes) = result.as_protobuf_bytes()?;
-    assert_eq!(type_name, "test.SimpleMessage");
-    assert!(!result_bytes.is_empty());
+    let sv = result.as_struct().unwrap();
+    assert_eq!(sv.type_name(), "test.SimpleMessage");
+    assert!(!sv.to_bytes().is_empty());
 
     Ok(())
 }
 
 #[test]
-fn test_as_protobuf_bytes_error_on_non_struct() -> Result<(), Error> {
+fn test_as_struct_none_on_non_struct() -> Result<(), Error> {
     let env = Env::builder().build()?;
 
     let program = env.compile("42")?;
     let result = program.evaluate(&Activation::new())?;
 
-    assert!(result.as_protobuf_bytes().is_err());
+    assert!(result.as_struct().is_none());
 
     Ok(())
 }
@@ -989,15 +985,14 @@ fn test_as_protobuf_bytes_error_on_non_struct() -> Result<(), Error> {
 fn test_struct_value_from_value() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("msg", "test.SimpleMessage")?
+        .declare_variable_with_type("msg", ValueType::Struct(StructType::new("test.SimpleMessage")))?
         .build()?;
 
     let bytes = encode_simple_message("Bob", 99);
 
-    let activation = Activation::new().bind_protobuf_variable(
+    let activation = Activation::new().bind_variable_dynamic(
         "msg",
-        "test.SimpleMessage",
-        &bytes,
+        StructValue::from_bytes("test.SimpleMessage", bytes.as_slice()),
     )?;
 
     let program = env.compile("msg")?;
@@ -1005,12 +1000,12 @@ fn test_struct_value_from_value() -> Result<(), Error> {
 
     // Extract via FromValue
     let sv = StructValue::from_value(&result)?;
-    assert_eq!(sv.type_name, "test.SimpleMessage");
-    assert!(!sv.bytes.is_empty());
+    assert_eq!(sv.type_name(), "test.SimpleMessage");
+    assert!(!sv.to_bytes().is_empty());
 
     // Extract via borrowed reference
     let sv_ref = <&StructValue>::from_value(&result)?;
-    assert_eq!(sv_ref.type_name, "test.SimpleMessage");
+    assert_eq!(sv_ref.type_name(), "test.SimpleMessage");
 
     Ok(())
 }
@@ -1030,87 +1025,87 @@ fn test_struct_value_from_value_error_on_non_struct() -> Result<(), Error> {
 // =============================================================================
 
 #[test]
-fn test_get_protobuf_field_string() -> Result<(), Error> {
+fn test_get_struct_field_string() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("msg", "test.SimpleMessage")?
+        .declare_variable_with_type("msg", ValueType::Struct(StructType::new("test.SimpleMessage")))?
         .build()?;
 
     let bytes = encode_simple_message("Alice", 42);
     let activation =
-        Activation::new().bind_protobuf_variable("msg", "test.SimpleMessage", &bytes)?;
+        Activation::new().bind_variable_dynamic("msg", StructValue::from_bytes("test.SimpleMessage", bytes.as_slice()))?;
 
     let result = env.compile("msg")?.evaluate(&activation)?;
     let sv = StructValue::from_value(&result)?;
 
-    let name = env.get_protobuf_field(&sv, "name")?;
+    let name = env.get_struct_field(&sv, "name")?;
     assert_eq!(name, Value::String("Alice".into()));
 
     Ok(())
 }
 
 #[test]
-fn test_get_protobuf_field_int() -> Result<(), Error> {
+fn test_get_struct_field_int() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("msg", "test.SimpleMessage")?
+        .declare_variable_with_type("msg", ValueType::Struct(StructType::new("test.SimpleMessage")))?
         .build()?;
 
     let bytes = encode_simple_message("Bob", 99);
     let activation =
-        Activation::new().bind_protobuf_variable("msg", "test.SimpleMessage", &bytes)?;
+        Activation::new().bind_variable_dynamic("msg", StructValue::from_bytes("test.SimpleMessage", bytes.as_slice()))?;
 
     let result = env.compile("msg")?.evaluate(&activation)?;
     let sv = StructValue::from_value(&result)?;
 
-    let id = env.get_protobuf_field(&sv, "id")?;
+    let id = env.get_struct_field(&sv, "id")?;
     assert_eq!(id, Value::Int(99));
 
     Ok(())
 }
 
 #[test]
-fn test_get_protobuf_field_nested() -> Result<(), Error> {
+fn test_get_struct_field_nested() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("person", "test.Person")?
+        .declare_variable_with_type("person", ValueType::Struct(StructType::new("test.Person")))?
         .build()?;
 
     let addr = encode_address("123 Main St", "Springfield", "62704");
     let bytes = encode_person("Alice", 30, Some(&addr), 1, &["rust"], true);
     let activation =
-        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+        Activation::new().bind_variable_dynamic("person", StructValue::from_bytes("test.Person", bytes.as_slice()))?;
 
     let result = env.compile("person")?.evaluate(&activation)?;
     let sv = StructValue::from_value(&result)?;
 
     // Get the nested address field
-    let address_value = env.get_protobuf_field(&sv, "address")?;
+    let address_value = env.get_struct_field(&sv, "address")?;
     let address_sv = StructValue::from_value(&address_value)?;
 
     // Now get city from the nested address
-    let city = env.get_protobuf_field(&address_sv, "city")?;
+    let city = env.get_struct_field(&address_sv, "city")?;
     assert_eq!(city, Value::String("Springfield".into()));
 
     Ok(())
 }
 
 #[test]
-fn test_get_protobuf_field_not_found() -> Result<(), Error> {
+fn test_get_struct_field_not_found() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("msg", "test.SimpleMessage")?
+        .declare_variable_with_type("msg", ValueType::Struct(StructType::new("test.SimpleMessage")))?
         .build()?;
 
     let bytes = encode_simple_message("Alice", 42);
     let activation =
-        Activation::new().bind_protobuf_variable("msg", "test.SimpleMessage", &bytes)?;
+        Activation::new().bind_variable_dynamic("msg", StructValue::from_bytes("test.SimpleMessage", bytes.as_slice()))?;
 
     let result = env.compile("msg")?.evaluate(&activation)?;
     let sv = StructValue::from_value(&result)?;
 
     // cel-cpp returns an error Value for non-existent fields
-    let field = env.get_protobuf_field(&sv, "nonexistent");
+    let field = env.get_struct_field(&sv, "nonexistent");
     match field {
         Err(_) => {} // status error
         Ok(Value::Error(_)) => {} // error value
@@ -1121,45 +1116,45 @@ fn test_get_protobuf_field_not_found() -> Result<(), Error> {
 }
 
 #[test]
-fn test_has_protobuf_field() -> Result<(), Error> {
+fn test_has_struct_field() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("person", "test.Person")?
+        .declare_variable_with_type("person", ValueType::Struct(StructType::new("test.Person")))?
         .build()?;
 
     let addr = encode_address("123 Main St", "Springfield", "62704");
     let bytes = encode_person("Alice", 30, Some(&addr), 1, &["rust"], true);
     let activation =
-        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+        Activation::new().bind_variable_dynamic("person", StructValue::from_bytes("test.Person", bytes.as_slice()))?;
 
     let result = env.compile("person")?.evaluate(&activation)?;
     let sv = StructValue::from_value(&result)?;
 
-    assert!(env.has_protobuf_field(&sv, "name")?);
-    assert!(env.has_protobuf_field(&sv, "address")?);
+    assert!(env.has_struct_field(&sv, "name")?);
+    assert!(env.has_struct_field(&sv, "address")?);
     // "active" is true, so has() returns true
-    assert!(env.has_protobuf_field(&sv, "active")?);
+    assert!(env.has_struct_field(&sv, "active")?);
 
     // Empty person — fields at defaults
     let empty_bytes = encode_person("", 0, None, 0, &[], false);
     let activation2 =
-        Activation::new().bind_protobuf_variable("person", "test.Person", &empty_bytes)?;
+        Activation::new().bind_variable_dynamic("person", StructValue::from_bytes("test.Person", empty_bytes.as_slice()))?;
     let result2 = env.compile("person")?.evaluate(&activation2)?;
     let sv2 = StructValue::from_value(&result2)?;
 
     // Proto3 default values: has() returns false for default-valued fields
-    assert!(!env.has_protobuf_field(&sv2, "name")?);
-    assert!(!env.has_protobuf_field(&sv2, "address")?);
-    assert!(!env.has_protobuf_field(&sv2, "active")?);
+    assert!(!env.has_struct_field(&sv2, "name")?);
+    assert!(!env.has_struct_field(&sv2, "address")?);
+    assert!(!env.has_struct_field(&sv2, "active")?);
 
     Ok(())
 }
 
 #[test]
-fn test_get_protobuf_field_wkt() -> Result<(), Error> {
+fn test_get_struct_field_wkt() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("event", "test.Event")?
+        .declare_variable_with_type("event", ValueType::Struct(StructType::new("test.Event")))?
         .build()?;
 
     let ttl = encode_duration(3600, 0);
@@ -1175,13 +1170,13 @@ fn test_get_protobuf_field_wkt() -> Result<(), Error> {
         None,
     );
     let activation =
-        Activation::new().bind_protobuf_variable("event", "test.Event", &bytes)?;
+        Activation::new().bind_variable_dynamic("event", StructValue::from_bytes("test.Event", bytes.as_slice()))?;
 
     let result = env.compile("event")?.evaluate(&activation)?;
     let sv = StructValue::from_value(&result)?;
 
     // Duration field should return a CEL duration value
-    let ttl_value = env.get_protobuf_field(&sv, "ttl")?;
+    let ttl_value = env.get_struct_field(&sv, "ttl")?;
     match &ttl_value {
         Value::Duration(d) => {
             assert_eq!(d.num_seconds(), 3600);
@@ -1190,7 +1185,7 @@ fn test_get_protobuf_field_wkt() -> Result<(), Error> {
     }
 
     // Timestamp field should return a CEL timestamp value
-    let ts_value = env.get_protobuf_field(&sv, "created_at")?;
+    let ts_value = env.get_struct_field(&sv, "created_at")?;
     match &ts_value {
         Value::Timestamp(_) => {} // ok, it's a timestamp
         other => panic!("Expected Value::Timestamp, got: {other:?}"),
@@ -1212,18 +1207,18 @@ fn test_message_construction_simple() -> Result<(), Error> {
     let program = env.compile("test.SimpleMessage{name: 'Bob', id: 25}")?;
     let result = program.evaluate(&Activation::new())?;
 
-    let (type_name, bytes) = result.as_protobuf_bytes()?;
-    assert_eq!(type_name, "test.SimpleMessage");
-    assert!(!bytes.is_empty());
+    let sv = result.as_struct().unwrap();
+    assert_eq!(sv.type_name(), "test.SimpleMessage");
+    assert!(!sv.to_bytes().is_empty());
 
     // Verify by binding the result back and reading fields
     let env2 = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("msg", "test.SimpleMessage")?
+        .declare_variable_with_type("msg", ValueType::Struct(StructType::new("test.SimpleMessage")))?
         .build()?;
 
     let activation =
-        Activation::new().bind_protobuf_variable("msg", "test.SimpleMessage", bytes)?;
+        Activation::new().bind_variable_dynamic("msg", StructValue::from_bytes("test.SimpleMessage", sv.to_bytes()))?;
 
     let program = env2.compile("msg.name == 'Bob' && msg.id == 25")?;
     let result = program.evaluate(&activation)?;
@@ -1243,17 +1238,17 @@ fn test_message_construction_with_nested() -> Result<(), Error> {
     )?;
     let result = program.evaluate(&Activation::new())?;
 
-    let (type_name, bytes) = result.as_protobuf_bytes()?;
-    assert_eq!(type_name, "test.Person");
+    let sv = result.as_struct().unwrap();
+    assert_eq!(sv.type_name(), "test.Person");
 
     // Verify nested field access
     let env2 = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("person", "test.Person")?
+        .declare_variable_with_type("person", ValueType::Struct(StructType::new("test.Person")))?
         .build()?;
 
     let activation =
-        Activation::new().bind_protobuf_variable("person", "test.Person", bytes)?;
+        Activation::new().bind_variable_dynamic("person", StructValue::from_bytes("test.Person", sv.to_bytes()))?;
 
     let program = env2.compile("person.address.city == 'NYC' && person.active == true")?;
     let result = program.evaluate(&activation)?;
@@ -1273,17 +1268,17 @@ fn test_message_construction_with_repeated() -> Result<(), Error> {
     )?;
     let result = program.evaluate(&Activation::new())?;
 
-    let (type_name, bytes) = result.as_protobuf_bytes()?;
-    assert_eq!(type_name, "test.Order");
+    let sv = result.as_struct().unwrap();
+    assert_eq!(sv.type_name(), "test.Order");
 
     // Verify round-trip
     let env2 = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("order", "test.Order")?
+        .declare_variable_with_type("order", ValueType::Struct(StructType::new("test.Order")))?
         .build()?;
 
     let activation =
-        Activation::new().bind_protobuf_variable("order", "test.Order", bytes)?;
+        Activation::new().bind_variable_dynamic("order", StructValue::from_bytes("test.Order", sv.to_bytes()))?;
 
     let program = env2.compile("order.buyer.name == 'Carol' && order.items.size() == 2 && order.items[1].price == 250")?;
     let result = program.evaluate(&activation)?;
@@ -1310,12 +1305,12 @@ fn test_message_construction_field_access_inline() -> Result<(), Error> {
 fn test_message_construction_equality() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("msg", "test.SimpleMessage")?
+        .declare_variable_with_type("msg", ValueType::Struct(StructType::new("test.SimpleMessage")))?
         .build()?;
 
     let bytes = encode_simple_message("Dan", 42);
     let activation =
-        Activation::new().bind_protobuf_variable("msg", "test.SimpleMessage", &bytes)?;
+        Activation::new().bind_variable_dynamic("msg", StructValue::from_bytes("test.SimpleMessage", bytes.as_slice()))?;
 
     // Constructed message should equal the bound variable with same content
     let program = env.compile("msg == test.SimpleMessage{name: 'Dan', id: 42}")?;
@@ -1335,14 +1330,14 @@ fn test_message_construction_equality() -> Result<(), Error> {
 fn test_has_proto3_field_presence() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("person", "test.Person")?
+        .declare_variable_with_type("person", ValueType::Struct(StructType::new("test.Person")))?
         .build()?;
 
     // Person with all fields set
     let addr = encode_address("123 Main St", "Springfield", "62704");
     let bytes = encode_person("Alice", 30, Some(&addr), 1, &["rust"], true);
     let activation =
-        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+        Activation::new().bind_variable_dynamic("person", StructValue::from_bytes("test.Person", bytes.as_slice()))?;
 
     // has() returns true for non-default fields
     let cases = [
@@ -1359,7 +1354,7 @@ fn test_has_proto3_field_presence() -> Result<(), Error> {
     // Empty person — all fields at proto3 defaults
     let empty_bytes = encode_person("", 0, None, 0, &[], false);
     let activation2 =
-        Activation::new().bind_protobuf_variable("person", "test.Person", &empty_bytes)?;
+        Activation::new().bind_variable_dynamic("person", StructValue::from_bytes("test.Person", empty_bytes.as_slice()))?;
 
     // has() returns false for default-valued proto3 fields
     let default_cases = [
@@ -1382,13 +1377,13 @@ fn test_has_proto3_field_presence() -> Result<(), Error> {
 fn test_type_on_message_value() -> Result<(), Error> {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("person", "test.Person")?
+        .declare_variable_with_type("person", ValueType::Struct(StructType::new("test.Person")))?
         .build()?;
 
     let addr = encode_address("123 Main St", "Springfield", "62704");
     let bytes = encode_person("Alice", 30, Some(&addr), 1, &["rust"], true);
     let activation =
-        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+        Activation::new().bind_variable_dynamic("person", StructValue::from_bytes("test.Person", bytes.as_slice()))?;
 
     // type() should return the message type name
     let program = env.compile("type(person) == test.Person")?;
@@ -1404,7 +1399,7 @@ fn test_type_on_message_value() -> Result<(), Error> {
 fn test_error_unknown_type_compile() {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
-        .declare_protobuf_variable("msg", "test.DoesNotExist")
+        .declare_variable_with_type("msg", ValueType::Struct(StructType::new("test.DoesNotExist")))
         .unwrap()
         .build()
         .unwrap();
@@ -1421,16 +1416,16 @@ fn test_error_unknown_type_compile() {
 }
 
 #[test]
-fn test_error_get_protobuf_field_unknown_type() {
+fn test_error_get_struct_field_unknown_type() {
     let env = Env::builder()
         .with_file_descriptor_set(&TEST_DESCRIPTORS)
         .build()
         .unwrap();
 
     // Construct a StructValue with a type name not in the descriptor pool
-    let sv = StructValue::new("test.NonExistent", vec![]);
+    let sv = StructValue::from_bytes("test.NonExistent", vec![]);
 
-    let result = env.get_protobuf_field(&sv, "name");
+    let result = env.get_struct_field(&sv, "name");
     assert!(result.is_err(), "expected error for unknown type");
     let err_msg = result.unwrap_err().to_string();
     assert!(

--- a/tests/protobuf.rs
+++ b/tests/protobuf.rs
@@ -1,0 +1,1440 @@
+use cel_cxx::*;
+use std::sync::LazyLock;
+
+static TEST_DESCRIPTORS: LazyLock<Vec<u8>> = LazyLock::new(|| {
+    use prost::Message;
+    protox::compile(["tests/fixtures/test.proto"], ["tests/fixtures/"])
+        .unwrap()
+        .encode_to_vec()
+});
+
+#[test]
+fn test_env_with_custom_descriptor_pool() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .build()?;
+
+    // Basic expression should still work
+    let program = env.compile("1 + 2")?;
+    let result = program.evaluate(&Activation::new())?;
+    assert_eq!(result, Value::Int(3));
+
+    Ok(())
+}
+
+#[test]
+fn test_well_known_types_with_custom_pool() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .build()?;
+
+    // duration() should still work — verifies generated_pool underlay
+    let program = env.compile("duration('3600s') == duration('1h')")?;
+    let result = program.evaluate(&Activation::new())?;
+    assert_eq!(result, Value::Bool(true));
+
+    // timestamp() should still work
+    let program =
+        env.compile("timestamp('2023-01-01T00:00:00Z') < timestamp('2024-01-01T00:00:00Z')")?;
+    let result = program.evaluate(&Activation::new())?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+#[test]
+fn test_default_env_still_works() -> Result<(), Error> {
+    // Verify no regression — default env (no custom pool) still works
+    let env = Env::builder().build()?;
+
+    let program = env.compile("'hello' + ' ' + 'world'")?;
+    let result = program.evaluate(&Activation::new())?;
+    assert_eq!(result, Value::String("hello world".into()));
+
+    Ok(())
+}
+
+/// Build serialized protobuf bytes for test.SimpleMessage using prost encoding.
+/// prost encoding matches standard protobuf wire format.
+fn encode_simple_message(name: &str, id: i32) -> Vec<u8> {
+    use prost::encoding::*;
+
+    let mut buf = Vec::new();
+    // field 1: string name (tag = 0x0a)
+    if !name.is_empty() {
+        encode_key(1, WireType::LengthDelimited, &mut buf);
+        encode_varint(name.len() as u64, &mut buf);
+        buf.extend_from_slice(name.as_bytes());
+    }
+    // field 2: int32 id (tag = 0x10)
+    if id != 0 {
+        encode_key(2, WireType::Varint, &mut buf);
+        encode_varint(id as i64 as u64, &mut buf);
+    }
+    buf
+}
+
+// --- Low-level encoding helpers ---
+
+fn encode_string_field(buf: &mut Vec<u8>, field_number: u32, value: &str) {
+    use prost::encoding::*;
+    if !value.is_empty() {
+        encode_key(field_number, WireType::LengthDelimited, buf);
+        encode_varint(value.len() as u64, buf);
+        buf.extend_from_slice(value.as_bytes());
+    }
+}
+
+fn encode_varint_field(buf: &mut Vec<u8>, field_number: u32, value: i32) {
+    use prost::encoding::*;
+    if value != 0 {
+        encode_key(field_number, WireType::Varint, buf);
+        encode_varint(value as i64 as u64, buf);
+    }
+}
+
+fn encode_bool_field(buf: &mut Vec<u8>, field_number: u32, value: bool) {
+    use prost::encoding::*;
+    if value {
+        encode_key(field_number, WireType::Varint, buf);
+        encode_varint(1, buf);
+    }
+}
+
+fn encode_nested_field(buf: &mut Vec<u8>, field_number: u32, nested: &[u8]) {
+    use prost::encoding::*;
+    if !nested.is_empty() {
+        encode_key(field_number, WireType::LengthDelimited, buf);
+        encode_varint(nested.len() as u64, buf);
+        buf.extend_from_slice(nested);
+    }
+}
+
+fn encode_repeated_strings(buf: &mut Vec<u8>, field_number: u32, values: &[&str]) {
+    use prost::encoding::*;
+    for v in values {
+        encode_key(field_number, WireType::LengthDelimited, buf);
+        encode_varint(v.len() as u64, buf);
+        buf.extend_from_slice(v.as_bytes());
+    }
+}
+
+fn encode_map_string_string(buf: &mut Vec<u8>, field_number: u32, entries: &[(&str, &str)]) {
+    use prost::encoding::*;
+    for (key, value) in entries {
+        // Each map entry is a nested message with key=field1, value=field2
+        let mut entry = Vec::new();
+        encode_string_field(&mut entry, 1, key);
+        encode_string_field(&mut entry, 2, value);
+
+        encode_key(field_number, WireType::LengthDelimited, buf);
+        encode_varint(entry.len() as u64, buf);
+        buf.extend_from_slice(&entry);
+    }
+}
+
+// --- Message-level encoding helpers ---
+
+fn encode_address(street: &str, city: &str, zip: &str) -> Vec<u8> {
+    let mut buf = Vec::new();
+    encode_string_field(&mut buf, 1, street);
+    encode_string_field(&mut buf, 2, city);
+    encode_string_field(&mut buf, 3, zip);
+    buf
+}
+
+fn encode_person(
+    name: &str,
+    age: i32,
+    address: Option<&[u8]>,
+    status: i32,
+    tags: &[&str],
+    active: bool,
+) -> Vec<u8> {
+    let mut buf = Vec::new();
+    encode_string_field(&mut buf, 1, name);
+    encode_varint_field(&mut buf, 2, age);
+    if let Some(addr) = address {
+        encode_nested_field(&mut buf, 3, addr);
+    }
+    encode_varint_field(&mut buf, 4, status);
+    encode_repeated_strings(&mut buf, 5, tags);
+    encode_bool_field(&mut buf, 6, active);
+    buf
+}
+
+fn encode_item(name: &str, price: i32) -> Vec<u8> {
+    let mut buf = Vec::new();
+    encode_string_field(&mut buf, 1, name);
+    encode_varint_field(&mut buf, 2, price);
+    buf
+}
+
+fn encode_order(buyer: Option<&[u8]>, items: &[&[u8]], labels: &[(&str, &str)]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    if let Some(b) = buyer {
+        encode_nested_field(&mut buf, 1, b);
+    }
+    for item in items {
+        encode_nested_field(&mut buf, 2, item);
+    }
+    encode_map_string_string(&mut buf, 3, labels);
+    buf
+}
+
+fn encode_bytes_field(buf: &mut Vec<u8>, field_number: u32, value: &[u8]) {
+    use prost::encoding::*;
+    if !value.is_empty() {
+        encode_key(field_number, WireType::LengthDelimited, buf);
+        encode_varint(value.len() as u64, buf);
+        buf.extend_from_slice(value);
+    }
+}
+
+fn encode_varint_i64_field(buf: &mut Vec<u8>, field_number: u32, value: i64) {
+    use prost::encoding::*;
+    if value != 0 {
+        encode_key(field_number, WireType::Varint, buf);
+        #[allow(clippy::cast_sign_loss)]
+        encode_varint(value as u64, buf);
+    }
+}
+
+// --- WKT encoding helpers ---
+
+fn encode_duration(seconds: i64, nanos: i32) -> Vec<u8> {
+    let mut buf = Vec::new();
+    encode_varint_i64_field(&mut buf, 1, seconds);
+    encode_varint_field(&mut buf, 2, nanos);
+    buf
+}
+
+fn encode_timestamp(seconds: i64, nanos: i32) -> Vec<u8> {
+    let mut buf = Vec::new();
+    encode_varint_i64_field(&mut buf, 1, seconds);
+    encode_varint_field(&mut buf, 2, nanos);
+    buf
+}
+
+fn encode_int64_value(value: i64) -> Vec<u8> {
+    let mut buf = Vec::new();
+    encode_varint_i64_field(&mut buf, 1, value);
+    buf
+}
+
+fn encode_string_value(value: &str) -> Vec<u8> {
+    let mut buf = Vec::new();
+    encode_string_field(&mut buf, 1, value);
+    buf
+}
+
+fn encode_bool_value(value: bool) -> Vec<u8> {
+    let mut buf = Vec::new();
+    encode_bool_field(&mut buf, 1, value);
+    buf
+}
+
+/// Encode a google.protobuf.Struct with string-typed values.
+/// Struct layout: field 1 = repeated MapEntry (map<string, Value>)
+/// MapEntry: {1: string key, 2: Value message}
+/// Value with string: {3: string_value}
+fn encode_struct_with_string_values(entries: &[(&str, &str)]) -> Vec<u8> {
+    use prost::encoding::*;
+    let mut buf = Vec::new();
+    for (key, val) in entries {
+        // Value message: field 3 = string_value
+        let mut value_msg = Vec::new();
+        encode_string_field(&mut value_msg, 3, val);
+
+        // MapEntry: {1: key, 2: Value}
+        let mut entry = Vec::new();
+        encode_string_field(&mut entry, 1, key);
+        encode_nested_field(&mut entry, 2, &value_msg);
+
+        // Struct field 1 = map<string, Value> entries
+        encode_key(1, WireType::LengthDelimited, &mut buf);
+        encode_varint(entry.len() as u64, &mut buf);
+        buf.extend_from_slice(&entry);
+    }
+    buf
+}
+
+fn encode_any(type_url: &str, value: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    encode_string_field(&mut buf, 1, type_url);
+    encode_bytes_field(&mut buf, 2, value);
+    buf
+}
+
+fn encode_event(
+    name: &str,
+    created_at: Option<&[u8]>,
+    ttl: Option<&[u8]>,
+    optional_count: Option<&[u8]>,
+    optional_label: Option<&[u8]>,
+    optional_flag: Option<&[u8]>,
+    metadata: Option<&[u8]>,
+    payload: Option<&[u8]>,
+) -> Vec<u8> {
+    let mut buf = Vec::new();
+    encode_string_field(&mut buf, 1, name);
+    if let Some(v) = created_at {
+        encode_nested_field(&mut buf, 2, v);
+    }
+    if let Some(v) = ttl {
+        encode_nested_field(&mut buf, 3, v);
+    }
+    if let Some(v) = optional_count {
+        encode_nested_field(&mut buf, 4, v);
+    }
+    if let Some(v) = optional_label {
+        encode_nested_field(&mut buf, 5, v);
+    }
+    if let Some(v) = optional_flag {
+        encode_nested_field(&mut buf, 6, v);
+    }
+    if let Some(v) = metadata {
+        encode_nested_field(&mut buf, 7, v);
+    }
+    if let Some(v) = payload {
+        encode_nested_field(&mut buf, 8, v);
+    }
+    buf
+}
+
+#[test]
+fn test_bind_protobuf_variable_field_access() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("msg", "test.SimpleMessage")?
+        .build()?;
+
+    let bytes = encode_simple_message("Alice", 42);
+
+    let activation = Activation::new().bind_protobuf_variable(
+        "msg",
+        "test.SimpleMessage",
+        &bytes,
+    )?;
+
+    // Test string field access
+    let program = env.compile("msg.name == 'Alice'")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    // Test int field access
+    let program = env.compile("msg.id > 0")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    // Test combined field access
+    let program = env.compile("msg.name == 'Alice' && msg.id == 42")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+#[test]
+fn test_protobuf_value_roundtrip() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("msg", "test.SimpleMessage")?
+        .build()?;
+
+    let bytes = encode_simple_message("Bob", 99);
+
+    let activation = Activation::new().bind_protobuf_variable(
+        "msg",
+        "test.SimpleMessage",
+        &bytes,
+    )?;
+
+    // Evaluate `msg` directly — should get a Value::Struct back
+    let program = env.compile("msg")?;
+    let result = program.evaluate(&activation)?;
+
+    match &result {
+        Value::Struct(s) => {
+            assert_eq!(s.type_name, "test.SimpleMessage");
+            // The bytes should round-trip (serialize the same message back)
+            assert!(!s.bytes.is_empty());
+        }
+        other => panic!("Expected Value::Struct, got: {other:?}"),
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_protobuf_field_access_string_result() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("msg", "test.SimpleMessage")?
+        .build()?;
+
+    let bytes = encode_simple_message("Charlie", 7);
+
+    let activation = Activation::new().bind_protobuf_variable(
+        "msg",
+        "test.SimpleMessage",
+        &bytes,
+    )?;
+
+    // Access a string field directly
+    let program = env.compile("msg.name")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::String("Charlie".into()));
+
+    // Access an int field directly
+    let program = env.compile("msg.id")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Int(7));
+
+    Ok(())
+}
+
+// =============================================================================
+// Phase 2A: Full Protobuf Field Access Tests
+// =============================================================================
+
+// --- 2A.1: Scalar fields ---
+
+#[test]
+fn test_scalar_bool_field() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("person", "test.Person")?
+        .build()?;
+
+    let addr = encode_address("123 Main St", "Springfield", "62704");
+    let bytes = encode_person("Alice", 30, Some(&addr), 1, &["rust"], true);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+
+    let program = env.compile("person.active == true")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+#[test]
+fn test_scalar_default_values() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("person", "test.Person")?
+        .build()?;
+
+    // Empty person — all fields at defaults
+    let bytes = encode_person("", 0, None, 0, &[], false);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+
+    let program = env.compile("person.age == 0 && person.active == false")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+// --- 2A.2: Nested message fields ---
+
+#[test]
+fn test_nested_message_field_access() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("person", "test.Person")?
+        .build()?;
+
+    let addr = encode_address("456 Market St", "San Francisco", "94105");
+    let bytes = encode_person("Bob", 25, Some(&addr), 0, &[], false);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+
+    let program = env.compile("person.address.city == 'San Francisco'")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+#[test]
+fn test_deeply_nested_field_access() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("order", "test.Order")?
+        .build()?;
+
+    let addr = encode_address("789 Broadway", "NYC", "10001");
+    let buyer = encode_person("Carol", 40, Some(&addr), 0, &[], false);
+    let bytes = encode_order(Some(&buyer), &[], &[]);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("order", "test.Order", &bytes)?;
+
+    let program = env.compile("order.buyer.address.city == 'NYC'")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+// --- 2A.3: Repeated fields ---
+
+#[test]
+fn test_repeated_string_size() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("person", "test.Person")?
+        .build()?;
+
+    let bytes = encode_person("Dave", 28, None, 0, &["rust", "cel", "proto"], false);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+
+    let program = env.compile("person.tags.size() == 3")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+#[test]
+fn test_repeated_string_index() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("person", "test.Person")?
+        .build()?;
+
+    let bytes = encode_person("Dave", 28, None, 0, &["rust", "cel", "proto"], false);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+
+    let program = env.compile("person.tags[0] == 'rust'")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+#[test]
+fn test_repeated_string_exists() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("person", "test.Person")?
+        .build()?;
+
+    let bytes = encode_person("Dave", 28, None, 0, &["rust", "cel", "proto"], false);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+
+    let program = env.compile("person.tags.exists(t, t == 'cel')")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+#[test]
+fn test_repeated_message_field() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("order", "test.Order")?
+        .build()?;
+
+    let item1 = encode_item("Widget", 100);
+    let item2 = encode_item("Gadget", 250);
+    let bytes = encode_order(None, &[&item1, &item2], &[]);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("order", "test.Order", &bytes)?;
+
+    let program = env.compile("order.items[0].name == 'Widget'")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+#[test]
+fn test_repeated_message_exists() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("order", "test.Order")?
+        .build()?;
+
+    let item1 = encode_item("Widget", 100);
+    let item2 = encode_item("Gadget", 250);
+    let bytes = encode_order(None, &[&item1, &item2], &[]);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("order", "test.Order", &bytes)?;
+
+    let program = env.compile("order.items.exists(i, i.price > 200)")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+#[test]
+fn test_repeated_empty() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("person", "test.Person")?
+        .build()?;
+
+    let bytes = encode_person("Eve", 22, None, 0, &[], false);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+
+    let program = env.compile("person.tags.size() == 0")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+// --- 2A.4: Map fields ---
+
+#[test]
+fn test_map_field_access() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("order", "test.Order")?
+        .build()?;
+
+    let bytes = encode_order(None, &[], &[("env", "prod"), ("region", "us-east")]);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("order", "test.Order", &bytes)?;
+
+    let program = env.compile(r#"order.labels["env"] == "prod""#)?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+#[test]
+fn test_map_contains_key() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("order", "test.Order")?
+        .build()?;
+
+    let bytes = encode_order(None, &[], &[("env", "prod"), ("region", "us-east")]);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("order", "test.Order", &bytes)?;
+
+    let program = env.compile(r#""env" in order.labels"#)?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+#[test]
+fn test_map_size() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("order", "test.Order")?
+        .build()?;
+
+    let bytes = encode_order(None, &[], &[("env", "prod"), ("region", "us-east")]);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("order", "test.Order", &bytes)?;
+
+    let program = env.compile("order.labels.size() == 2")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+// --- 2A.5: Enum fields ---
+
+#[test]
+fn test_enum_field_as_int() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("person", "test.Person")?
+        .build()?;
+
+    // status = STATUS_ACTIVE = 1
+    let bytes = encode_person("Frank", 35, None, 1, &[], false);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+
+    let program = env.compile("person.status == 1")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+#[test]
+fn test_enum_field_named_constant() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("person", "test.Person")?
+        .build()?;
+
+    // status = STATUS_ACTIVE = 1
+    let bytes = encode_person("Grace", 29, None, 1, &[], false);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+
+    let program = env.compile("person.status == test.Status.STATUS_ACTIVE")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+#[test]
+fn test_enum_field_default() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("person", "test.Person")?
+        .build()?;
+
+    // status = STATUS_UNSPECIFIED = 0 (default)
+    let bytes = encode_person("Hank", 50, None, 0, &[], false);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+
+    let program = env.compile("person.status == 0")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+// =============================================================================
+// Phase 2B: Well-Known Type Handling Tests
+// =============================================================================
+
+// --- 2B.1: Duration fields ---
+
+#[test]
+fn test_wkt_duration_field() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("event", "test.Event")?
+        .build()?;
+
+    let ttl = encode_duration(3600, 0);
+    let bytes = encode_event("test", None, Some(&ttl), None, None, None, None, None);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("event", "test.Event", &bytes)?;
+
+    let program = env.compile("event.ttl == duration('3600s')")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+#[test]
+fn test_wkt_duration_comparison() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("event", "test.Event")?
+        .build()?;
+
+    let ttl = encode_duration(3600, 0); // 1 hour
+    let bytes = encode_event("test", None, Some(&ttl), None, None, None, None, None);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("event", "test.Event", &bytes)?;
+
+    // 30m = 1800s, so 3600s > 1800s
+    let program = env.compile("event.ttl > duration('1800s')")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+// --- 2B.2: Timestamp fields ---
+
+#[test]
+fn test_wkt_timestamp_field() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("event", "test.Event")?
+        .build()?;
+
+    // 2024-01-01T00:00:00Z = 1704067200 seconds since epoch
+    let created_at = encode_timestamp(1704067200, 0);
+    let bytes = encode_event("test", Some(&created_at), None, None, None, None, None, None);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("event", "test.Event", &bytes)?;
+
+    let program = env.compile("event.created_at == timestamp('2024-01-01T00:00:00Z')")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+#[test]
+fn test_wkt_timestamp_comparison() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("event", "test.Event")?
+        .build()?;
+
+    // 2024-01-01T00:00:00Z
+    let created_at = encode_timestamp(1704067200, 0);
+    let bytes = encode_event("test", Some(&created_at), None, None, None, None, None, None);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("event", "test.Event", &bytes)?;
+
+    let program = env.compile("event.created_at > timestamp('2023-01-01T00:00:00Z')")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+// --- 2B.3: Wrapper types ---
+
+#[test]
+fn test_wkt_int64_wrapper() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("event", "test.Event")?
+        .build()?;
+
+    let count = encode_int64_value(42);
+    let bytes = encode_event("test", None, None, Some(&count), None, None, None, None);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("event", "test.Event", &bytes)?;
+
+    let program = env.compile("event.optional_count == 42")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+#[test]
+fn test_wkt_string_wrapper() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("event", "test.Event")?
+        .build()?;
+
+    let label = encode_string_value("important");
+    let bytes = encode_event("test", None, None, None, Some(&label), None, None, None);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("event", "test.Event", &bytes)?;
+
+    let program = env.compile("event.optional_label == 'important'")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+#[test]
+fn test_wkt_bool_wrapper() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("event", "test.Event")?
+        .build()?;
+
+    let flag = encode_bool_value(true);
+    let bytes = encode_event("test", None, None, None, None, Some(&flag), None, None);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("event", "test.Event", &bytes)?;
+
+    let program = env.compile("event.optional_flag == true")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+// --- 2B.4: Struct/Value fields ---
+
+#[test]
+fn test_wkt_struct_field_access() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("event", "test.Event")?
+        .build()?;
+
+    let metadata = encode_struct_with_string_values(&[("env", "prod"), ("version", "1.0")]);
+    let bytes = encode_event("test", None, None, None, None, None, Some(&metadata), None);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("event", "test.Event", &bytes)?;
+
+    let program = env.compile("event.metadata.env == 'prod'")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+#[test]
+fn test_wkt_struct_has_key() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("event", "test.Event")?
+        .build()?;
+
+    let metadata = encode_struct_with_string_values(&[("env", "prod"), ("version", "1.0")]);
+    let bytes = encode_event("test", None, None, None, None, None, Some(&metadata), None);
+
+    let activation =
+        Activation::new().bind_protobuf_variable("event", "test.Event", &bytes)?;
+
+    let program = env.compile("has(event.metadata.env)")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+// --- 2B.5: Any fields ---
+
+#[test]
+fn test_wkt_any_type_url() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("event", "test.Event")?
+        .build()?;
+
+    // Pack a SimpleMessage into Any
+    let inner = encode_simple_message("packed", 1);
+    let payload = encode_any("type.googleapis.com/test.SimpleMessage", &inner);
+    let bytes = encode_event("test", None, None, None, None, None, None, Some(&payload));
+
+    let activation =
+        Activation::new().bind_protobuf_variable("event", "test.Event", &bytes)?;
+
+    // Try to check if the Any field is present via has()
+    let program = env.compile("has(event.payload)")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+// =============================================================================
+// Phase 3B: Extract Protobuf Bytes from Evaluation Results
+// =============================================================================
+
+#[test]
+fn test_as_protobuf_bytes() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("msg", "test.SimpleMessage")?
+        .build()?;
+
+    let bytes = encode_simple_message("Alice", 42);
+
+    let activation = Activation::new().bind_protobuf_variable(
+        "msg",
+        "test.SimpleMessage",
+        &bytes,
+    )?;
+
+    let program = env.compile("msg")?;
+    let result = program.evaluate(&activation)?;
+
+    let (type_name, result_bytes) = result.as_protobuf_bytes()?;
+    assert_eq!(type_name, "test.SimpleMessage");
+    assert!(!result_bytes.is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn test_as_protobuf_bytes_error_on_non_struct() -> Result<(), Error> {
+    let env = Env::builder().build()?;
+
+    let program = env.compile("42")?;
+    let result = program.evaluate(&Activation::new())?;
+
+    assert!(result.as_protobuf_bytes().is_err());
+
+    Ok(())
+}
+
+#[test]
+fn test_struct_value_from_value() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("msg", "test.SimpleMessage")?
+        .build()?;
+
+    let bytes = encode_simple_message("Bob", 99);
+
+    let activation = Activation::new().bind_protobuf_variable(
+        "msg",
+        "test.SimpleMessage",
+        &bytes,
+    )?;
+
+    let program = env.compile("msg")?;
+    let result = program.evaluate(&activation)?;
+
+    // Extract via FromValue
+    let sv = StructValue::from_value(&result)?;
+    assert_eq!(sv.type_name, "test.SimpleMessage");
+    assert!(!sv.bytes.is_empty());
+
+    // Extract via borrowed reference
+    let sv_ref = <&StructValue>::from_value(&result)?;
+    assert_eq!(sv_ref.type_name, "test.SimpleMessage");
+
+    Ok(())
+}
+
+#[test]
+fn test_struct_value_from_value_error_on_non_struct() -> Result<(), Error> {
+    let result = Value::Int(42);
+
+    assert!(StructValue::from_value(&result).is_err());
+    assert!(<&StructValue>::from_value(&result).is_err());
+
+    Ok(())
+}
+
+// =============================================================================
+// Phase 3C: Rust-side Protobuf Field Access
+// =============================================================================
+
+#[test]
+fn test_get_protobuf_field_string() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("msg", "test.SimpleMessage")?
+        .build()?;
+
+    let bytes = encode_simple_message("Alice", 42);
+    let activation =
+        Activation::new().bind_protobuf_variable("msg", "test.SimpleMessage", &bytes)?;
+
+    let result = env.compile("msg")?.evaluate(&activation)?;
+    let sv = StructValue::from_value(&result)?;
+
+    let name = env.get_protobuf_field(&sv, "name")?;
+    assert_eq!(name, Value::String("Alice".into()));
+
+    Ok(())
+}
+
+#[test]
+fn test_get_protobuf_field_int() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("msg", "test.SimpleMessage")?
+        .build()?;
+
+    let bytes = encode_simple_message("Bob", 99);
+    let activation =
+        Activation::new().bind_protobuf_variable("msg", "test.SimpleMessage", &bytes)?;
+
+    let result = env.compile("msg")?.evaluate(&activation)?;
+    let sv = StructValue::from_value(&result)?;
+
+    let id = env.get_protobuf_field(&sv, "id")?;
+    assert_eq!(id, Value::Int(99));
+
+    Ok(())
+}
+
+#[test]
+fn test_get_protobuf_field_nested() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("person", "test.Person")?
+        .build()?;
+
+    let addr = encode_address("123 Main St", "Springfield", "62704");
+    let bytes = encode_person("Alice", 30, Some(&addr), 1, &["rust"], true);
+    let activation =
+        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+
+    let result = env.compile("person")?.evaluate(&activation)?;
+    let sv = StructValue::from_value(&result)?;
+
+    // Get the nested address field
+    let address_value = env.get_protobuf_field(&sv, "address")?;
+    let address_sv = StructValue::from_value(&address_value)?;
+
+    // Now get city from the nested address
+    let city = env.get_protobuf_field(&address_sv, "city")?;
+    assert_eq!(city, Value::String("Springfield".into()));
+
+    Ok(())
+}
+
+#[test]
+fn test_get_protobuf_field_not_found() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("msg", "test.SimpleMessage")?
+        .build()?;
+
+    let bytes = encode_simple_message("Alice", 42);
+    let activation =
+        Activation::new().bind_protobuf_variable("msg", "test.SimpleMessage", &bytes)?;
+
+    let result = env.compile("msg")?.evaluate(&activation)?;
+    let sv = StructValue::from_value(&result)?;
+
+    // cel-cpp returns an error Value for non-existent fields
+    let field = env.get_protobuf_field(&sv, "nonexistent");
+    match field {
+        Err(_) => {} // status error
+        Ok(Value::Error(_)) => {} // error value
+        Ok(other) => panic!("Expected error for nonexistent field, got: {other:?}"),
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_has_protobuf_field() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("person", "test.Person")?
+        .build()?;
+
+    let addr = encode_address("123 Main St", "Springfield", "62704");
+    let bytes = encode_person("Alice", 30, Some(&addr), 1, &["rust"], true);
+    let activation =
+        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+
+    let result = env.compile("person")?.evaluate(&activation)?;
+    let sv = StructValue::from_value(&result)?;
+
+    assert!(env.has_protobuf_field(&sv, "name")?);
+    assert!(env.has_protobuf_field(&sv, "address")?);
+    // "active" is true, so has() returns true
+    assert!(env.has_protobuf_field(&sv, "active")?);
+
+    // Empty person — fields at defaults
+    let empty_bytes = encode_person("", 0, None, 0, &[], false);
+    let activation2 =
+        Activation::new().bind_protobuf_variable("person", "test.Person", &empty_bytes)?;
+    let result2 = env.compile("person")?.evaluate(&activation2)?;
+    let sv2 = StructValue::from_value(&result2)?;
+
+    // Proto3 default values: has() returns false for default-valued fields
+    assert!(!env.has_protobuf_field(&sv2, "name")?);
+    assert!(!env.has_protobuf_field(&sv2, "address")?);
+    assert!(!env.has_protobuf_field(&sv2, "active")?);
+
+    Ok(())
+}
+
+#[test]
+fn test_get_protobuf_field_wkt() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("event", "test.Event")?
+        .build()?;
+
+    let ttl = encode_duration(3600, 0);
+    let created_at = encode_timestamp(1704067200, 0);
+    let bytes = encode_event(
+        "test_event",
+        Some(&created_at),
+        Some(&ttl),
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    let activation =
+        Activation::new().bind_protobuf_variable("event", "test.Event", &bytes)?;
+
+    let result = env.compile("event")?.evaluate(&activation)?;
+    let sv = StructValue::from_value(&result)?;
+
+    // Duration field should return a CEL duration value
+    let ttl_value = env.get_protobuf_field(&sv, "ttl")?;
+    match &ttl_value {
+        Value::Duration(d) => {
+            assert_eq!(d.num_seconds(), 3600);
+        }
+        other => panic!("Expected Value::Duration, got: {other:?}"),
+    }
+
+    // Timestamp field should return a CEL timestamp value
+    let ts_value = env.get_protobuf_field(&sv, "created_at")?;
+    match &ts_value {
+        Value::Timestamp(_) => {} // ok, it's a timestamp
+        other => panic!("Expected Value::Timestamp, got: {other:?}"),
+    }
+
+    Ok(())
+}
+
+// =============================================================================
+// Phase 4: Message Construction in CEL Expressions
+// =============================================================================
+
+#[test]
+fn test_message_construction_simple() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .build()?;
+
+    let program = env.compile("test.SimpleMessage{name: 'Bob', id: 25}")?;
+    let result = program.evaluate(&Activation::new())?;
+
+    let (type_name, bytes) = result.as_protobuf_bytes()?;
+    assert_eq!(type_name, "test.SimpleMessage");
+    assert!(!bytes.is_empty());
+
+    // Verify by binding the result back and reading fields
+    let env2 = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("msg", "test.SimpleMessage")?
+        .build()?;
+
+    let activation =
+        Activation::new().bind_protobuf_variable("msg", "test.SimpleMessage", bytes)?;
+
+    let program = env2.compile("msg.name == 'Bob' && msg.id == 25")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+#[test]
+fn test_message_construction_with_nested() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .build()?;
+
+    let program = env.compile(
+        "test.Person{name: 'Alice', age: 30, address: test.Address{street: '123 Main', city: 'NYC', zip: '10001'}, active: true}",
+    )?;
+    let result = program.evaluate(&Activation::new())?;
+
+    let (type_name, bytes) = result.as_protobuf_bytes()?;
+    assert_eq!(type_name, "test.Person");
+
+    // Verify nested field access
+    let env2 = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("person", "test.Person")?
+        .build()?;
+
+    let activation =
+        Activation::new().bind_protobuf_variable("person", "test.Person", bytes)?;
+
+    let program = env2.compile("person.address.city == 'NYC' && person.active == true")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+#[test]
+fn test_message_construction_with_repeated() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .build()?;
+
+    let program = env.compile(
+        "test.Order{buyer: test.Person{name: 'Carol'}, items: [test.Item{name: 'Widget', price: 100}, test.Item{name: 'Gadget', price: 250}]}",
+    )?;
+    let result = program.evaluate(&Activation::new())?;
+
+    let (type_name, bytes) = result.as_protobuf_bytes()?;
+    assert_eq!(type_name, "test.Order");
+
+    // Verify round-trip
+    let env2 = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("order", "test.Order")?
+        .build()?;
+
+    let activation =
+        Activation::new().bind_protobuf_variable("order", "test.Order", bytes)?;
+
+    let program = env2.compile("order.buyer.name == 'Carol' && order.items.size() == 2 && order.items[1].price == 250")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+#[test]
+fn test_message_construction_field_access_inline() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .build()?;
+
+    // Access a field directly on a constructed message — no round-trip needed
+    let program = env.compile("test.SimpleMessage{name: 'Eve', id: 7}.name")?;
+    let result = program.evaluate(&Activation::new())?;
+    assert_eq!(result, Value::String("Eve".into()));
+
+    Ok(())
+}
+
+#[test]
+fn test_message_construction_equality() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("msg", "test.SimpleMessage")?
+        .build()?;
+
+    let bytes = encode_simple_message("Dan", 42);
+    let activation =
+        Activation::new().bind_protobuf_variable("msg", "test.SimpleMessage", &bytes)?;
+
+    // Constructed message should equal the bound variable with same content
+    let program = env.compile("msg == test.SimpleMessage{name: 'Dan', id: 42}")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+// =============================================================================
+// Phase 6: Advanced Features & Polish
+// =============================================================================
+
+// --- 6.1: Dedicated has() tests for proto3 field presence ---
+
+#[test]
+fn test_has_proto3_field_presence() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("person", "test.Person")?
+        .build()?;
+
+    // Person with all fields set
+    let addr = encode_address("123 Main St", "Springfield", "62704");
+    let bytes = encode_person("Alice", 30, Some(&addr), 1, &["rust"], true);
+    let activation =
+        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+
+    // has() returns true for non-default fields
+    let cases = [
+        ("has(person.name)", true),
+        ("has(person.age)", true),
+        ("has(person.address)", true),
+        ("has(person.active)", true),
+    ];
+    for (expr, expected) in &cases {
+        let result = env.compile(expr)?.evaluate(&activation)?;
+        assert_eq!(result, Value::Bool(*expected), "failed for: {expr}");
+    }
+
+    // Empty person — all fields at proto3 defaults
+    let empty_bytes = encode_person("", 0, None, 0, &[], false);
+    let activation2 =
+        Activation::new().bind_protobuf_variable("person", "test.Person", &empty_bytes)?;
+
+    // has() returns false for default-valued proto3 fields
+    let default_cases = [
+        ("has(person.name)", false),
+        ("has(person.age)", false),
+        ("has(person.address)", false),
+        ("has(person.active)", false),
+    ];
+    for (expr, expected) in &default_cases {
+        let result = env.compile(expr)?.evaluate(&activation2)?;
+        assert_eq!(result, Value::Bool(*expected), "failed for default: {expr}");
+    }
+
+    Ok(())
+}
+
+// --- 6.2: type() on message values ---
+
+#[test]
+fn test_type_on_message_value() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("person", "test.Person")?
+        .build()?;
+
+    let addr = encode_address("123 Main St", "Springfield", "62704");
+    let bytes = encode_person("Alice", 30, Some(&addr), 1, &["rust"], true);
+    let activation =
+        Activation::new().bind_protobuf_variable("person", "test.Person", &bytes)?;
+
+    // type() should return the message type name
+    let program = env.compile("type(person) == test.Person")?;
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Bool(true));
+
+    Ok(())
+}
+
+// --- 6.4: Error handling — descriptive error messages ---
+
+#[test]
+fn test_error_unknown_type_compile() {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_protobuf_variable("msg", "test.DoesNotExist")
+        .unwrap()
+        .build()
+        .unwrap();
+
+    // Compiling an expression that accesses a field on the unknown type should fail
+    // with a descriptive error message
+    let result = env.compile("msg.name");
+    assert!(result.is_err(), "expected compile error for unknown type field access");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("undeclared reference"),
+        "error should mention undeclared reference, got: {err_msg}"
+    );
+}
+
+#[test]
+fn test_error_get_protobuf_field_unknown_type() {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .build()
+        .unwrap();
+
+    // Construct a StructValue with a type name not in the descriptor pool
+    let sv = StructValue::new("test.NonExistent", vec![]);
+
+    let result = env.get_protobuf_field(&sv, "name");
+    assert!(result.is_err(), "expected error for unknown type");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("NonExistent") || err_msg.contains("not found"),
+        "error should mention the type name, got: {err_msg}"
+    );
+}

--- a/tests/protobuf_legacy_derive.rs
+++ b/tests/protobuf_legacy_derive.rs
@@ -1,0 +1,193 @@
+#![cfg(feature = "protobuf-legacy")]
+
+use cel_cxx::*;
+use std::sync::LazyLock;
+
+// Import protobuf-legacy generated types (with ProtobufLegacyValue derived via build.rs post-processing)
+#[allow(non_camel_case_types, non_snake_case, non_upper_case_globals, unused_mut)]
+mod proto {
+    include!(concat!(
+        env!("OUT_DIR"),
+        "/protobuf_legacy_gen/test.rs"
+    ));
+}
+
+use proto::*;
+
+static TEST_DESCRIPTORS: LazyLock<Vec<u8>> = LazyLock::new(|| {
+    use prost::Message;
+    protox::compile(["tests/fixtures/test.proto"], ["tests/fixtures/"])
+        .unwrap()
+        .encode_to_vec()
+});
+
+// --- TypedValue ---
+
+#[test]
+fn test_typed_value_returns_struct_type() {
+    let vt = <SimpleMessage as TypedValue>::value_type();
+    assert_eq!(vt, ValueType::Struct(StructType::new("test.SimpleMessage")));
+}
+
+#[test]
+fn test_typed_value_nested_type() {
+    let vt = <Person as TypedValue>::value_type();
+    assert_eq!(vt, ValueType::Struct(StructType::new("test.Person")));
+}
+
+// --- IntoValue ---
+
+#[test]
+fn test_into_value_produces_struct() {
+    let mut msg = SimpleMessage::new();
+    msg.name = "hello".into();
+    msg.id = 42;
+
+    let value = msg.into_value();
+    match &value {
+        Value::Struct(sv) => {
+            assert_eq!(sv.type_name(), "test.SimpleMessage");
+            assert!(!sv.to_bytes().is_empty());
+        }
+        other => panic!("expected Value::Struct, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_from_trait_conversion() {
+    let mut msg = SimpleMessage::new();
+    msg.name = "test".into();
+    msg.id = 1;
+
+    let value: Value = msg.into();
+    assert!(matches!(value, Value::Struct(_)));
+}
+
+// --- FromValue ---
+
+#[test]
+fn test_from_value_roundtrip() {
+    let mut original = SimpleMessage::new();
+    original.name = "roundtrip".into();
+    original.id = 99;
+
+    let value = original.clone().into_value();
+    let recovered = SimpleMessage::from_value(&value).unwrap();
+    assert_eq!(recovered, original);
+}
+
+#[test]
+fn test_try_from_value_owned() {
+    let mut msg = SimpleMessage::new();
+    msg.name = "try".into();
+    msg.id = 7;
+
+    let value = msg.clone().into_value();
+    let recovered = SimpleMessage::try_from(value).unwrap();
+    assert_eq!(recovered, msg);
+}
+
+#[test]
+fn test_try_from_value_ref() {
+    let mut msg = SimpleMessage::new();
+    msg.name = "ref".into();
+    msg.id = 8;
+
+    let value = msg.clone().into_value();
+    let recovered = SimpleMessage::try_from(&value).unwrap();
+    assert_eq!(recovered, msg);
+}
+
+#[test]
+fn test_from_value_wrong_type_returns_error() {
+    let value = Value::Int(42);
+    let result = SimpleMessage::from_value(&value);
+    assert!(result.is_err());
+}
+
+// --- Full CEL integration ---
+
+#[test]
+fn test_declare_and_bind_protobuf_legacy_message() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_variable::<SimpleMessage>("msg")?
+        .build()?;
+
+    let program = env.compile("msg.name")?;
+
+    let mut msg = SimpleMessage::new();
+    msg.name = "Alice".into();
+    msg.id = 1;
+
+    let activation = Activation::new().bind_variable("msg", msg)?;
+
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::String("Alice".into()));
+    Ok(())
+}
+
+#[test]
+fn test_cel_field_access_int() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_variable::<SimpleMessage>("msg")?
+        .build()?;
+
+    let program = env.compile("msg.id")?;
+
+    let mut msg = SimpleMessage::new();
+    msg.name = "Bob".into();
+    msg.id = 42;
+
+    let activation = Activation::new().bind_variable("msg", msg)?;
+
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::Int(42));
+    Ok(())
+}
+
+#[test]
+fn test_nested_message_roundtrip() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_variable::<Person>("p")?
+        .build()?;
+
+    let program = env.compile("p.address.city")?;
+
+    let mut address = Address::new();
+    address.street = "123 Main St".into();
+    address.city = "Springfield".into();
+    address.zip = "62701".into();
+
+    let mut person = Person::new();
+    person.name = "Charlie".into();
+    person.age = 30;
+    person.address = ::protobuf::MessageField::some(address);
+    person.status = proto::Status::STATUS_ACTIVE.into();
+    person.tags = vec!["admin".into()];
+    person.active = true;
+
+    let activation = Activation::new().bind_variable("p", person)?;
+
+    let result = program.evaluate(&activation)?;
+    assert_eq!(result, Value::String("Springfield".into()));
+    Ok(())
+}
+
+#[test]
+fn test_cel_eval_returns_message_and_from_value() -> Result<(), Error> {
+    let env = Env::builder()
+        .with_file_descriptor_set(&TEST_DESCRIPTORS)
+        .declare_variable::<SimpleMessage>("msg")?
+        .build()?;
+
+    let program = env.compile("test.SimpleMessage{name: 'constructed', id: 100}")?;
+    let result = program.evaluate(&Activation::new())?;
+
+    let recovered = SimpleMessage::from_value(&result).unwrap();
+    assert_eq!(recovered.name, "constructed");
+    assert_eq!(recovered.id, 100);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds first-class Protocol Buffer message support to cel-cxx, enabling users to bind serialized protobuf messages as CEL variables, access all field types in expressions, construct new messages, and extract results back to Rust — all powered by cel-cpp's existing protobuf runtime.

## What's included

**Core functionality:**
- `EnvBuilder::with_file_descriptor_set()` — load custom `.proto` types from a compiled `FileDescriptorSet`
- `EnvBuilder::declare_protobuf_variable()` / `Activation::bind_protobuf_variable()` — declare and bind protobuf messages as CEL variables
- Full CEL field access: scalars, nested messages, repeated fields, maps, enums (including named constants like `test.Status.STATUS_ACTIVE`)
- Well-known types auto-convert: `Duration` → CEL duration, `Timestamp` → CEL timestamp, wrappers auto-unbox, `Struct` behaves as map
- `Value::as_protobuf_bytes()` and `StructValue::from_value()` — extract protobuf results
- `Env::get_protobuf_field()` / `Env::has_protobuf_field()` — Rust-side field access without re-evaluating CEL
- Message construction in CEL via `Type{field: value}` syntax

**Build & tooling:**
- Replaced `cel_cxx::protoc` module (which shelled out to `protoc` binary) with `protox` (pure-Rust protobuf compiler) as a dev-dependency — tests and examples compile `.proto` files at runtime with no external tooling required
- Deleted pre-compiled `test_descriptors.bin`; tests use `LazyLock` to compile descriptors once per process
- Added `examples/protobuf-advanced.rs` demonstrating nested messages, repeated fields, maps, enums, WKTs, comprehensions, message construction, and Rust-side field extraction
- New "Protobuf Integration" section in README recommending `protox`, with `protoc` as alternative

**Warning cleanup:**
- Suppressed `-Wnullability-completeness` C++ warnings from upstream cel-cpp headers (Apple Clang)
- Removed unused CXX bridge type aliases (`Time`, `Duration` in `decl.rs`; `MutSpan_Expr`, `MutSpan_ListExprElement`, `MutSpan_StructExprField`, `MutSpan_MapExprEntry` in `parser.rs`) — these were declared in bridge blocks but never referenced by any function signature

**Tests:**
- 51 new protobuf-specific integration tests covering scalars, nested messages, repeated fields, maps, enums, well-known types, `has()`, `type()`, message construction, round-trips, error handling
- Updated feature table: Protobuf Message Type status changed from 🚧 to ✅

## Pre-existing bugs fixed

- **Use-after-free in `NewDescriptorPool`** (`protobuf.h`): was stack-allocating a `SimpleDescriptorDatabase` and passing a pointer to `DescriptorPool`; the database was destroyed when the function returned. Fixed by using `DescriptorPool(generated_pool())` underlay with `BuildFile()` per file.
- **`StructType` FFI size mismatch**: `Rep<usize, 2>` (16 bytes) didn't match C++ `sizeof(StructType)` which is 24 bytes due to `absl::variant` index overhead on `StructTypeVariant`. Fixed to `Rep<usize, 3>`.
- **`size_t`→`int` truncation in `ParseFromArray`** (`protobuf.h`): `file_descriptor_set.size()` was passed directly to `ParseFromArray` which takes `int`, with no bounds check. Added bounds check.

## Key design decisions

- **Serialize/deserialize at the FFI boundary**: protobuf messages cross Rust↔C++ as bytes rather than pointers. This is the correct approach given that the Rust and C++ sides link against separate protobuf library instances. See the Performance Note in README for details on why zero-copy isn't feasible today.
- **`StructValue { type_name, bytes }`**: messages are stored as type name + serialized bytes on the Rust side, deserialized into arena-allocated C++ `MessageValue` at the FFI boundary. This keeps the Rust API simple and avoids lifetime entanglement with C++ arenas.
- **Thread safety**: `DynamicMessageFactory` is not thread-safe. `Ctx::clone()` creates a fresh factory for dynamic contexts to prevent data races during concurrent evaluation.
- **Enum resolution**: cel-cpp's type checker auto-resolves enums from the `DescriptorPool`, but the runtime resolver needs them registered separately via `TypeRegistry`. Added `TypeRegistry_register_enums_from_file_descriptor_set` and enabled `enable_qualified_type_identifiers` on `RuntimeOptions` so named enum constants (e.g. `test.Status.STATUS_ACTIVE`) work end-to-end.
- **`StructType` size**: C++ `StructType` is 24 bytes (not 16) due to `absl::variant` index overhead on `StructTypeVariant`. The FFI `Rep` wrapper was updated to `Rep<usize, 3>` to match.

## Testing done

- `cargo test --tests` — 191 tests pass, zero warnings
- `cargo run --example protobuf`
- `cargo run --example protobuf-advanced`
- 20 consecutive multi-threaded test runs with no SIGSEGV

Closes #1