### PR TITLE
Build improvements and cleanup

### DIFF
--- a/crates/cel-build-utils/src/lib.rs
+++ b/crates/cel-build-utils/src/lib.rs
@@ -155,6 +155,17 @@ impl Build {
     }
 
     pub fn try_build(&mut self) -> Result<Artifacts> {
+        // Short-circuit: use pre-built artifacts if CEL_PREBUILT_DIR is set.
+        // This skips the entire Bazel build, useful for environments where
+        // Bazel cannot download dependencies (e.g. corporate networks).
+        //
+        // Expected layout:
+        //   $CEL_PREBUILT_DIR/lib/libcel.a
+        //   $CEL_PREBUILT_DIR/include/  (cel-cpp + abseil + protobuf headers)
+        if let Ok(prebuilt) = env::var("CEL_PREBUILT_DIR") {
+            return self.use_prebuilt(&prebuilt);
+        }
+
         let target = self.target.as_ref().context("TARGET dir not set")?;
         let out_dir = self.out_dir.as_ref().context("OUT_DIR not set")?;
         if !out_dir.exists() {
@@ -264,6 +275,55 @@ impl Build {
             include_dir: install_include_dir,
             libs,
             target: target.to_owned(),
+        })
+    }
+
+    /// Use pre-built CEL artifacts instead of building from source.
+    ///
+    /// Copies the pre-built `lib/` and `include/` trees into `$OUT_DIR/cel/install/`
+    /// so the rest of the build (cxx bridge compilation) finds them in the
+    /// same location as a normal Bazel build.
+    fn use_prebuilt(&self, prebuilt_dir: &str) -> Result<Artifacts> {
+        let dir = PathBuf::from(prebuilt_dir);
+        let src_lib = dir.join("lib");
+        let src_include = dir.join("include");
+
+        let libcel = if cfg!(windows) { "cel.lib" } else { "libcel.a" };
+        anyhow::ensure!(
+            src_lib.join(libcel).exists(),
+            "CEL_PREBUILT_DIR={prebuilt_dir}: {libcel} not found in {}",
+            src_lib.display()
+        );
+        anyhow::ensure!(
+            src_include.exists(),
+            "CEL_PREBUILT_DIR={prebuilt_dir}: include/ directory not found"
+        );
+
+        // Copy into $OUT_DIR/cel/install/ so cxx_build finds the headers
+        let out_dir = self.out_dir.as_ref().context("OUT_DIR not set")?;
+        let install_dir = out_dir.join("install");
+        if install_dir.exists() {
+            fs::remove_dir_all(&install_dir)?;
+        }
+        let install_lib = install_dir.join("lib");
+        let install_inc = install_dir.join("include");
+        fs::create_dir_all(&install_lib)?;
+        cp_r(&src_include, &install_inc)?;
+        fs::copy(src_lib.join(libcel), install_lib.join(libcel))?;
+
+        println!(
+            "cargo:warning=Using pre-built CEL from {} (skip Bazel)",
+            dir.display()
+        );
+
+        Ok(Artifacts {
+            lib_dir: install_lib,
+            include_dir: install_inc,
+            libs: vec!["cel".to_owned()],
+            target: self
+                .target
+                .clone()
+                .unwrap_or_else(|| "unknown".to_owned()),
         })
     }
 

--- a/crates/cel-cxx-ffi/build.rs
+++ b/crates/cel-cxx-ffi/build.rs
@@ -70,6 +70,7 @@ fn build_ffi(artifacts: &Artifacts) -> Result<()> {
         .flag_if_supported("-Wno-return-type")
         .flag_if_supported("-Wno-sign-compare")
         .flag_if_supported("-Wno-missing-requires")
+        .flag_if_supported("-Wno-nullability-completeness")
         .flag_if_supported("/nologo")
         .flag_if_supported("/EHsc")
         .flag_if_supported("/D_CRT_SECURE_NO_DEPRECATE")

--- a/crates/cel-cxx-ffi/src/common/decl.rs
+++ b/crates/cel-cxx-ffi/src/common/decl.rs
@@ -1,4 +1,4 @@
-use crate::absl::{Duration, Status, Timestamp};
+use crate::absl::Status;
 use crate::common::{Type, Constant};
 
 #[cxx::bridge]
@@ -6,10 +6,7 @@ mod ffi {
     #[namespace = "absl"]
     unsafe extern "C++" {
         include!(<absl/status/status.h>);
-        include!(<absl/time/time.h>);
         type Status = super::Status;
-        type Time = super::Timestamp;
-        type Duration = super::Duration;
     }
 
     #[namespace = "cel"]

--- a/crates/cel-cxx-ffi/src/parser.rs
+++ b/crates/cel-cxx-ffi/src/parser.rs
@@ -1,4 +1,4 @@
-use crate::absl::{Status, StringView, MutSpan};
+use crate::absl::{Status, StringView};
 use crate::common::{Expr, ListExprElement, StructExprField, MapExprEntry};
 use std::pin::Pin;
 
@@ -56,11 +56,6 @@ mod ffi {
         include!(<cel-cxx-ffi/include/parser.h>);
 
         type MacroPredicate;
-
-        type MutSpan_Expr<'a> = super::MutSpan<'a, Expr>;
-        type MutSpan_ListExprElement<'a> = super::MutSpan<'a, ListExprElement>;
-        type MutSpan_StructExprField<'a> = super::MutSpan<'a, StructExprField>;
-        type MutSpan_MapExprEntry<'a> = super::MutSpan<'a, MapExprEntry>;
 
         // GlobalMacroExpander
         fn GlobalMacroExpander_new(ffi_expander: Box<AnyFfiGlobalMacroExpander>) -> UniquePtr<GlobalMacroExpander>;


### PR DESCRIPTION
## Summary

- Add `CEL_PREBUILT_DIR` environment variable to `cel-build-utils` to skip the Bazel build when pre-built C++ artifacts are available
- Suppress `-Wnullability-completeness` warnings from upstream protobuf headers in the FFI build
- Remove unused CXX type alias declarations from `decl.rs` and `parser.rs`

## Testing

All existing tests pass (`cargo test --tests`), no clippy warnings.