### PR TITLE
Fix pre-existing bugs across Rust source code

### DIFF
--- a/crates/cel-cxx-ffi/src/absl.rs
+++ b/crates/cel-cxx-ffi/src/absl.rs
@@ -549,10 +549,18 @@ impl<'a, T: 'a + SpanElement> Span<'a, T> {
 
 impl<'a, T: 'a + SpanElement + cxx::vector::VectorElement> Span<'a, T> {
     pub fn from_vector(vector: &'a cxx::CxxVector<T>) -> Self {
-        Self {
-            ptr: unsafe { vector.get_unchecked(0) as *const T },
-            len: vector.len(),
-            _marker: std::marker::PhantomData,
+        if vector.is_empty() {
+            Self {
+                ptr: std::ptr::NonNull::dangling().as_ptr(),
+                len: 0,
+                _marker: std::marker::PhantomData,
+            }
+        } else {
+            Self {
+                ptr: unsafe { vector.get_unchecked(0) as *const T },
+                len: vector.len(),
+                _marker: std::marker::PhantomData,
+            }
         }
     }
 }
@@ -589,10 +597,8 @@ impl<'a, T: 'a + SpanElement> std::iter::Iterator for SpanIter<'a, T> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (
-            self.span.len() - self.index,
-            Some(self.span.len() - self.index),
-        )
+        let remaining = self.span.len().saturating_sub(self.index);
+        (remaining, Some(remaining))
     }
 }
 
@@ -627,6 +633,10 @@ pub struct MutSpan<'a, T: 'a + MutSpanElement> {
     _marker: std::marker::PhantomData<&'a mut T>,
 }
 
+// Copy + Clone are required by cxx::kind::Trivial for FFI interop.
+// SAFETY: callers must not use a copied MutSpan to produce aliased &mut references.
+// In practice, MutSpan is only iterated once via iter()/into_iter() immediately after
+// creation from from_vector(), so no aliasing occurs.
 impl<'a, T: 'a + MutSpanElement> Copy for MutSpan<'a, T> {}
 impl<'a, T: 'a + MutSpanElement> Clone for MutSpan<'a, T> {
     fn clone(&self) -> Self {
@@ -662,18 +672,29 @@ impl<'a, T: 'a + MutSpanElement> MutSpan<'a, T> {
 
     pub fn iter(&self) -> MutSpanIter<'a, T> {
         MutSpanIter {
-            span: *self,
+            ptr: self.ptr,
+            len: self.len,
             index: 0,
+            _marker: std::marker::PhantomData,
         }
     }
 }
 
 impl<'a, T: 'a + MutSpanElement + cxx::vector::VectorElement> MutSpan<'a, T> {
     pub fn from_vector(mut vector: Pin<&'a mut cxx::CxxVector<T>>) -> Self {
-        Self {
-            ptr: unsafe { vector.as_mut().index_unchecked_mut(0).get_unchecked_mut() as *mut T },
-            len: vector.len(),
-            _marker: std::marker::PhantomData,
+        let len = vector.len();
+        if len == 0 {
+            Self {
+                ptr: std::ptr::NonNull::dangling().as_ptr(),
+                len: 0,
+                _marker: std::marker::PhantomData,
+            }
+        } else {
+            Self {
+                ptr: unsafe { vector.as_mut().index_unchecked_mut(0).get_unchecked_mut() as *mut T },
+                len,
+                _marker: std::marker::PhantomData,
+            }
         }
     }
 }
@@ -693,27 +714,32 @@ impl<'a, T: 'a + MutSpanElement + cxx::ExternType<Kind = cxx::kind::Trivial>> Mu
 }
 
 pub struct MutSpanIter<'a, T: 'a + MutSpanElement> {
-    span: MutSpan<'a, T>,
+    ptr: *mut T,
+    len: usize,
     index: usize,
+    _marker: std::marker::PhantomData<&'a mut T>,
 }
 
 impl<'a, T: 'a + MutSpanElement> std::iter::Iterator for MutSpanIter<'a, T> {
     type Item = Pin<&'a mut T>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(item) = self.span.get(self.index) {
+        if self.index < self.len {
+            let item = unsafe {
+                self.ptr.byte_add(self.index * T::size_of())
+                    .as_mut()
+                    .map(|ptr| Pin::new_unchecked(ptr))
+            };
             self.index += 1;
-            Some(item)
+            item
         } else {
             None
         }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (
-            self.span.len() - self.index,
-            Some(self.span.len() - self.index),
-        )
+        let remaining = self.len.saturating_sub(self.index);
+        (remaining, Some(remaining))
     }
 }
 impl<'a, T: 'a + MutSpanElement> std::iter::FusedIterator for MutSpanIter<'a, T> {}
@@ -722,7 +748,12 @@ impl<'a, T: 'a + MutSpanElement> std::iter::IntoIterator for &MutSpan<'a, T> {
     type Item = Pin<&'a mut T>;
     type IntoIter = MutSpanIter<'a, T>;
     fn into_iter(self) -> Self::IntoIter {
-        MutSpanIter { span: *self, index: 0 }
+        MutSpanIter {
+            ptr: self.ptr,
+            len: self.len,
+            index: 0,
+            _marker: std::marker::PhantomData,
+        }
     }
 }
 

--- a/crates/cel-cxx-ffi/src/common/types.rs
+++ b/crates/cel-cxx-ffi/src/common/types.rs
@@ -644,7 +644,7 @@ impl<'a> std::ops::Index<usize> for TypeParameters<'a> {
     type Output = Type<'a>;
 
     fn index(&self, index: usize) -> &Self::Output {
-        unsafe { self.get_unchecked(index) }
+        self.get(index).expect("TypeParameters index out of bounds")
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -715,6 +715,7 @@ impl From<&Error> for crate::ffi::Status {
     fn from(value: &Error) -> Self {
         use crate::ffi::Status;
         match value.code() {
+            // OK status carries no message by convention; the message is intentionally dropped.
             Code::Ok => Status::ok(),
             Code::Cancelled => Status::cancelled(value.message()),
             Code::Unknown => Status::unknown(value.message()),

--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -241,7 +241,10 @@ fn mapkey_type_to_rust<'a>(type_: &Type<'a>) -> rust::MapKeyType {
             let type_param_type = type_.get_type_param();
             rust::MapKeyType::TypeParam(type_param_type_to_rust(&type_param_type))
         }
-        _ => rust::MapKeyType::Dyn,
+        other => {
+            debug_assert!(false, "unexpected map key type kind: {:?}", other);
+            rust::MapKeyType::Dyn
+        }
     }
 }
 

--- a/src/ffi/values.rs
+++ b/src/ffi/values.rs
@@ -70,7 +70,10 @@ pub(crate) fn value_from_rust<'a>(
             Value::new_map(&map_value)
         }
         rust::Value::Unknown(..) => {
-            todo!()
+            let error_value = ErrorValue::new(
+                super::Status::internal("cannot convert Unknown value to FFI"),
+            );
+            Value::new_error(&error_value)
         }
         rust::Value::Type(t) => {
             let type_ = super::type_from_rust(t, arena, descriptor_pool);
@@ -186,7 +189,7 @@ pub(crate) fn value_to_rust<'a>(
             Ok(rust::Value::Map(result))
         }
         ValueKind::Unknown => {
-            todo!()
+            Err(rust::Error::internal("Unknown values are not supported"))
         }
         ValueKind::Type => {
             let type_value = value.get_type();

--- a/src/macros/expr.rs
+++ b/src/macros/expr.rs
@@ -53,13 +53,13 @@ impl std::ops::Deref for Expr {
     type Target = ExprKind;
 
     fn deref(&self) -> &Self::Target {
-        self.kind.as_ref().unwrap()
+        self.kind.as_ref().expect("Expr has no kind set")
     }
 }
 
 impl std::ops::DerefMut for Expr {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.kind.as_mut().unwrap()
+        self.kind.as_mut().expect("Expr has no kind set")
     }
 }
 

--- a/src/program/inner.rs
+++ b/src/program/inner.rs
@@ -136,6 +136,9 @@ impl<'f> ProgramInner<'f> {
                     &ffi_activation,
                 )
                 .map_err(|ffi_status| Error::from(ffi_status))?;
+            if ffi_value.is_null() {
+                return Err(Error::unknown("evaluation returned null"));
+            }
             let value = ffi::value_to_rust(
                 &ffi_value,
                 eval_ctx.arena(),


### PR DESCRIPTION
## Summary

- Fix undefined behavior in `Span::from_vector` and `MutSpan::from_vector` when given empty vectors (null pointer dereference)
- Fix `TypeParameters::Index` bypassing bounds checks (could panic with unhelpful message)
- Fix `eval_async` missing null check on compilation result (present in `eval_sync` but missing in async path)
- Replace `todo!()` panics for `Unknown` value/type variants with proper error returns
- Improve panic messages in `Expr::Deref` (`unwrap()` → `expect()` with context)
- Add `debug_assert` in `mapkey_type_to_rust` before silent fallback to `Dyn`
- Fix `SpanIter`/`MutSpanIter` `size_hint` potential underflow (use `saturating_sub`)
- Add documentation comment on `Code::Ok` message-dropping behavior

## Testing

All existing tests pass (`cargo test --tests`), no clippy warnings. No behavioral changes to passing tests — all fixes address error paths or edge cases.